### PR TITLE
Fix SWA deploy path and tweet shortcode

### DIFF
--- a/.github/workflows/azure-static-web-apps-blue-plant-0a72bd81e.yml
+++ b/.github/workflows/azure-static-web-apps-blue-plant-0a72bd81e.yml
@@ -32,8 +32,7 @@ jobs:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_BLUE_PLANT_0A72BD81E }}
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           action: "upload"
-          app_location: "/"
-          app_artifact_location: "public"
+          app_location: "public"
           skip_app_build: true
 
   close_pull_request_job:

--- a/content/blog/the-importance-of-software-documentation.md
+++ b/content/blog/the-importance-of-software-documentation.md
@@ -12,7 +12,7 @@ Our team used to rely on an email or an individual design comp to contain all of
 
 A feature is no longer a hastily hacked together single-page update but a rich, well tested, accessible web experience built with reusable UI components and fueled by data-driven hypothesized business value. This level of complexity can no longer be tracked solely in conversations, chats, or emails and requires a centralized document. This project spec, or canonical document, not only acts as the single source of truth but is infinitely valuable when new team members join the project or leadership wants an overview of the project. [Isaac](https://twitter.com/isaach) summarized this concept well:
 
-{{< tweet 1367003154923937793 >}}
+{{< tweet user="isaach" id="1367003154923937793" >}}
 
 ## The Project Spec™
 


### PR DESCRIPTION
- Workflow: replace app_location "/" + app_artifact_location "public" with app_location "public" — the v1 action resolves the artifact path relative to app_location, so pointing it directly at the pre-built public/ dir is the reliable approach with skip_app_build
- Tweet shortcode: add required named params (user, id) to fix Hugo build error introduced by the shortcode API change

https://claude.ai/code/session_014JbWuPS8SdcPmXtTZT7oX5