### PR TITLE
Add Projects section with merge-bot as first entry

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -14,6 +14,7 @@ services:
 
 permalinks:
   blog: /:year/:month/:title/
+  projects: /projects/:slug/
 
 params:
   author: 'Chad Schulz'
@@ -46,15 +47,19 @@ menu:
       name: 'Home'
       url: '/'
       weight: 10
+    - identifier: 'projects'
+      name: 'Projects'
+      url: '/projects/'
+      weight: 20
     - identifier: 'about'
       name: 'About'
       url: 'https://github.com/squalrus'
-      weight: 20
+      weight: 30
     - identifier: 'tags'
       name: 'Tags'
       url: '/tags/'
-      weight: 30
+      weight: 40
     - identifier: 'chillout'
       name: 'Chillout'
       url: '/chillout-with-chad/'
-      weight: 40
+      weight: 50

--- a/content/blog/github-pull-request-management-with-github-actions.md
+++ b/content/blog/github-pull-request-management-with-github-actions.md
@@ -5,6 +5,8 @@ tags:
   - github
   - project
   - workflow
+projects:
+  - merge-bot
 ---
 
 ![](/img/blog/github-pull-request-management-with-github-actions/cover.jpg)

--- a/content/projects/_index.md
+++ b/content/projects/_index.md
@@ -1,0 +1,3 @@
+---
+title: "Projects"
+---

--- a/content/projects/merge-bot.md
+++ b/content/projects/merge-bot.md
@@ -1,0 +1,51 @@
+---
+title: "merge-bot"
+date: 2019-10-01T00:00:00+00:00
+description: "GitHub Action for automated PR merging based on labels, blocking labels, and reviewer sign-off."
+status: active
+repo: https://github.com/squalrus/merge-bot
+demo: ""
+tech:
+  - GitHub Actions
+  - TypeScript
+  - Node.js
+featured: true
+weight: 10
+---
+
+PR management for GitHub repos. merge-bot automates pull request integration by checking a configurable set of conditions before merging: required labels, blocking labels, and optional reviewer approval. Once conditions are met, the PR is merged with the method of your choice and the branch is cleaned up.
+
+It's designed to replace the manual label-watching and back-and-forth of "is this ready?" — wire it up, set your rules, and let the bot handle the rest.
+
+## Setup
+
+Add a workflow file at `.github/workflows/merge-bot.yml`:
+
+```yaml
+name: Merge Bot
+on:
+  pull_request:
+    types: [labeled, unlabeled, review_requested, review_request_removed]
+  pull_request_review:
+jobs:
+  merge:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: squalrus/merge-bot@v1
+      with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        labels: ready
+        blocking_labels: do not merge
+        method: squash
+```
+
+## Options
+
+| Option | Default | Description |
+|---|---|---|
+| `labels` | `ready` | Label(s) required before merging |
+| `blocking_labels` | `do not merge` | Label(s) that block the merge |
+| `reviewers` | `true` | Require all reviewers to approve |
+| `method` | `merge` | Merge method: `merge`, `squash`, or `rebase` |
+| `test` | `false` | Test mode — comments instead of merging |
+| `delete_source_branch` | `false` | Delete branch after merge |

--- a/themes/squalr/assets/css/components/_projects.scss
+++ b/themes/squalr/assets/css/components/_projects.scss
@@ -1,0 +1,101 @@
+.projects-list {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1.5rem;
+  padding: 0;
+  list-style: none;
+}
+
+@media (min-width: 640px) {
+  .projects-list {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.project-card {
+  background: $darkest-color;
+  border-left: 0.4em solid transparent;
+  padding: 1.5rem;
+  transition: border-color 0.35s;
+
+  &:hover {
+    border-left-color: $primary-color;
+  }
+}
+
+.project-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.project-card-title {
+  color: $lightest-color;
+  font-size: 1.1em;
+  font-weight: bold;
+  margin: 0;
+}
+
+.project-card-description {
+  font-size: 0.9em;
+  margin: 0.5rem 0 1rem;
+}
+
+.project-status {
+  flex-shrink: 0;
+  font-size: 0.7em;
+  padding: 0.15em 0.5em;
+  border-radius: 0.2em;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+
+  &.status-active {
+    background: rgba($primary-color, 0.15);
+    color: $primary-color;
+  }
+
+  &.status-archived {
+    background: rgba(255, 255, 255, 0.08);
+    color: $light-color;
+  }
+
+  &.status-wip {
+    background: rgba(255, 165, 0, 0.15);
+    color: #ffa500;
+  }
+}
+
+.project-card-links {
+  margin-top: 1rem;
+  font-size: 0.85em;
+
+  a {
+    margin-right: 1rem;
+  }
+}
+
+.project-detail-meta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+  font-size: 0.9em;
+}
+
+.project-detail-tech {
+  margin-bottom: 1.5rem;
+}
+
+.related-section {
+  margin-top: 3rem;
+  padding-top: 1.5rem;
+  border-top: 1px dashed rgba(255, 255, 255, 0.3);
+
+  h3 {
+    margin-top: 0;
+    margin-bottom: 1rem;
+  }
+}

--- a/themes/squalr/assets/css/main.scss
+++ b/themes/squalr/assets/css/main.scss
@@ -14,5 +14,6 @@ $primary-color: {{ .Site.Params.style.primaryColor | default "#52F0E0" }};
 @import 'components/posts_list';
 @import 'components/tag';
 @import 'components/tags_list';
+@import 'components/projects';
 
 @import 'extra';

--- a/themes/squalr/layouts/_default/single.html
+++ b/themes/squalr/layouts/_default/single.html
@@ -28,5 +28,6 @@
     <div class="post-content">
       {{ .Content }}
     </div>
+    {{ partial "related-projects.html" . }}
   </article>
 {{ end }}

--- a/themes/squalr/layouts/partials/project-card.html
+++ b/themes/squalr/layouts/partials/project-card.html
@@ -1,0 +1,26 @@
+<div class="project-card">
+  <div class="project-card-header">
+    <a class="project-card-title" href="{{ .Permalink }}">{{ .Title }}</a>
+    {{- with .Params.status }}
+    <span class="project-status status-{{ . }}">{{ . }}</span>
+    {{- end }}
+  </div>
+  {{- with .Params.description }}
+  <p class="project-card-description">{{ . }}</p>
+  {{- end }}
+  {{- with .Params.tech }}
+  <div>
+    {{- range . }}
+    <span class="tag">{{ . }}</span>
+    {{- end }}
+  </div>
+  {{- end }}
+  <div class="project-card-links">
+    {{- with .Params.repo }}
+    <a href="{{ . }}" target="_blank" rel="noreferrer noopener">GitHub ↗</a>
+    {{- end }}
+    {{- with .Params.demo }}
+    <a href="{{ . }}" target="_blank" rel="noreferrer noopener">Demo ↗</a>
+    {{- end }}
+  </div>
+</div>

--- a/themes/squalr/layouts/partials/related-projects.html
+++ b/themes/squalr/layouts/partials/related-projects.html
@@ -1,0 +1,11 @@
+{{- with .Params.projects }}
+<div class="related-section">
+  <h3>Related projects</h3>
+  {{- range . }}
+    {{- $project := site.GetPage (printf "/projects/%s" .) }}
+    {{- with $project }}
+      {{ partial "project-card.html" . }}
+    {{- end }}
+  {{- end }}
+</div>
+{{- end }}

--- a/themes/squalr/layouts/projects/list.html
+++ b/themes/squalr/layouts/projects/list.html
@@ -1,0 +1,10 @@
+{{ define "main" }}
+  <article>
+    <h1>{{ .Title }}</h1>
+    <ul class="projects-list">
+      {{- range sort .Pages "Params.weight" }}
+      <li>{{ partial "project-card.html" . }}</li>
+      {{- end }}
+    </ul>
+  </article>
+{{ end }}

--- a/themes/squalr/layouts/projects/single.html
+++ b/themes/squalr/layouts/projects/single.html
@@ -1,0 +1,46 @@
+{{ define "main" }}
+  <article class="post">
+    <header class="post-header">
+      <h1 class="post-title">{{ .Title }}</h1>
+      <div class="project-detail-meta">
+        {{- with .Params.status }}
+        <span class="project-status status-{{ . }}">{{ . }}</span>
+        {{- end }}
+        {{- with .Params.repo }}
+        <a href="{{ . }}" target="_blank" rel="noreferrer noopener">GitHub ↗</a>
+        {{- end }}
+        {{- with .Params.demo }}
+        <a href="{{ . }}" target="_blank" rel="noreferrer noopener">Demo ↗</a>
+        {{- end }}
+      </div>
+      {{- with .Params.tech }}
+      <div class="project-detail-tech">
+        {{- range . }}
+        <span class="tag">{{ . }}</span>
+        {{- end }}
+      </div>
+      {{- end }}
+    </header>
+    <div class="post-content">
+      {{ .Content }}
+    </div>
+    {{- $slug := .File.ContentBaseName }}
+    {{- $related := where site.RegularPages "Params.projects" "intersect" (slice $slug) }}
+    {{- with $related }}
+    <div class="related-section">
+      <h3>Related posts</h3>
+      <ul class="posts-list">
+        {{- range . }}
+        <li class="posts-list-item">
+          <a class="posts-list-item-title" href="{{ .Permalink }}">{{ .Title }}</a>
+          <span class="posts-list-item-description">
+            {{ partial "icon.html" (dict "ctx" $ "name" "calendar") }}
+            {{ .PublishDate.Format "Jan 2, 2006" }}
+          </span>
+        </li>
+        {{- end }}
+      </ul>
+    </div>
+    {{- end }}
+  </article>
+{{ end }}


### PR DESCRIPTION
Content:
- content/projects/_index.md — section index
- content/projects/merge-bot.md — merge-bot project page with description, tech stack, setup guide, and options table

Theme:
- layouts/projects/list.html — card grid sorted by weight
- layouts/projects/single.html — detail page with related posts
- partials/project-card.html — card with title, status badge, description, tech tags, GitHub/demo links
- partials/related-projects.html — shown at bottom of blog posts that reference a project via the projects: frontmatter key
- layouts/_default/single.html — wired in related-projects partial
- assets/css/components/_projects.scss — card grid, status badges, related section divider

Config:
- Added /projects/ to nav (weight 20, between Home and About)
- Added projects permalink: /projects/:slug/
- Incremented weights on Tags and Chillout nav items

Cross-link:
- github-pull-request-management post gets projects: [merge-bot] so the related project card appears at the bottom of the post

https://claude.ai/code/session_014JbWuPS8SdcPmXtTZT7oX5