### PR TITLE
Phase 3 polish: bio, dynamic copyright, tech taxonomy, CI cleanup

### DIFF
--- a/.github/workflows/azure-static-web-apps-blue-plant-0a72bd81e.yml
+++ b/.github/workflows/azure-static-web-apps-blue-plant-0a72bd81e.yml
@@ -16,8 +16,6 @@ jobs:
     name: Build and Deploy Job
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: true
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3
         with:

--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,7 @@
 baseURL: https://squalr.us/
 title: Chad Schulz
 theme: squalr
-copyright: '©2026 Chad Schulz'
+copyright: '© {{ now.Format "2006" }} Chad Schulz'
 paginate: 15
 
 languageCode: en-us
@@ -12,13 +12,17 @@ services:
   googleAnalytics:
     id: G-82PM3D1H9N
 
+taxonomies:
+  tag: tags
+  tech: tech
+
 permalinks:
   blog: /:year/:month/:title/
   projects: /projects/:slug/
 
 params:
   author: 'Chad Schulz'
-  description: 'Principal SDE Manager at Microsoft. Currently working on azure.com.'
+  description: 'Sr Consultant at Dura Digital.'
   avatar: '/img/bio.jpg'
   menu_item_separator: '-'
   favicon: '/img/favicon.ico'

--- a/themes/squalr/assets/css/components/_app.scss
+++ b/themes/squalr/assets/css/components/_app.scss
@@ -24,6 +24,13 @@
   }
 }
 
+.app-header-copyright {
+  display: block;
+  margin-top: 1.5rem;
+  font-size: 0.7em;
+  color: rgba($light-color, 0.5);
+}
+
 .app-header-title {
   color: $lightest-color;
   display: block;

--- a/themes/squalr/layouts/_default/baseof.html
+++ b/themes/squalr/layouts/_default/baseof.html
@@ -39,6 +39,7 @@
         {{ end }}
       </div>
       {{- end }}
+      <small class="app-header-copyright">© {{ now.Format "2006" }} {{ .Site.Params.author }}</small>
     </header>
     <main class="app-container">
       {{ block "main" . }}


### PR DESCRIPTION
- config.yaml: update description to Sr Consultant at Dura Digital
- config.yaml: add tech taxonomy so project tech: tags get browsable pages at /tech/<term>/ alongside the existing /tags/ taxonomy
- baseof.html: dynamic copyright year via {{ now.Format "2006" }} rendered in the sidebar; no longer needs manual update each year
- _app.scss: .app-header-copyright style (muted, small, sidebar bottom)
- CI workflow: remove submodules: true — no submodules in the repo

https://claude.ai/code/session_014JbWuPS8SdcPmXtTZT7oX5