### PR TITLE
Add three new posts, cleanup copyright field and stale CSP note

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,6 @@
 baseURL: https://squalr.us/
 title: Chad Schulz
 theme: squalr
-copyright: '© {{ now.Format "2006" }} Chad Schulz'
 paginate: 15
 
 languageCode: en-us

--- a/content/blog/a-blog-post-about-the-blog-youre-reading-this-post-on.md
+++ b/content/blog/a-blog-post-about-the-blog-youre-reading-this-post-on.md
@@ -6,6 +6,10 @@ tags:
   - workflow
 ---
 
+**Update (2026):** The CSP configuration and GA setup shown in this post reflect what was live at the time. Both have since been updated — GA migrated to GA4, domains updated to `googletagmanager.com`, and `unpkg.com`/`opensea.io` removed after the NFT embeds were dropped.
+
+---
+
 A few months ago I decided I wanted to do some blogging about technical challenges, process observations (and opinions), and some topics I would find valuable to have written down somewhere. I also find blogging cathartic as a means to get an idea, that could otherwise stay wedged, out of my head.
 
 ## The Web Developer's Blog Pitfall

--- a/content/blog/building-a-custom-hugo-theme.md
+++ b/content/blog/building-a-custom-hugo-theme.md
@@ -1,0 +1,89 @@
+---
+title: "Building a Custom Hugo Theme"
+date: 2026-06-04T00:00:00+00:00
+tags:
+  - process
+  - website
+  - workflow
+---
+
+The m10c theme served the blog well for five years. But at some point, a git submodule you don't own starts to feel less like a convenience and more like a dependency you can't audit.
+
+The final nudge: m10c is minimally maintained, wasn't pinned to a specific commit, and I was about to add a Projects section the theme had no concept of. Building a custom theme made more sense than trying to extend someone else's.
+
+## What Hugo themes actually are
+
+A Hugo theme is a directory inside `themes/` with a specific structure:
+
+```
+themes/squalr/
+├── assets/css/      # SCSS, compiled by Hugo's pipeline
+├── data/            # JSON data files (icons, etc.)
+├── layouts/         # HTML templates
+└── theme.toml       # Metadata
+```
+
+Hugo's template lookup tries your project's `layouts/` first, then the theme's. So you can override individual templates without touching the theme — useful when you need a one-off customization without forking everything.
+
+The CSS pipeline runs through Hugo itself. No npm, no webpack, no node_modules. You write SCSS, Hugo compiles and fingerprints it. That's it.
+
+## Porting from m10c
+
+Phase one was parity: a new theme that looks identical to the old one. I initialized the submodule to read the source, then ported each file:
+
+- `_base.scss` — reset, typography, link styles
+- `components/_app.scss` — the fixed sidebar and main container
+- `components/_post.scss` — content area, blockquotes, code blocks
+- Remaining components: tags, pagination, 404, icons
+
+The templates were almost a direct copy. The main change: removing the Disqus footer call from `single.html` (it was wired up but never used) and removing a Microsoft auth script from `baseof.html` that had crept in from work tooling.
+
+One thing worth doing: the m10c theme ships with all 400+ Feather icons as a 53KB JSON file. The templates use nine of them. I extracted those nine into `data/squalr/icons.json` — now 2KB. Smaller payload, no external dependency.
+
+## The icon partial
+
+m10c renders icons from a JSON data file using an inline SVG partial. The partial looks up the icon name in `$.Site.Data.m10c.icons`. Porting to the custom theme meant updating that path to `$.Site.Data.squalr.icons` — one-line change, but easy to miss.
+
+```html
+{{- if isset .ctx.Site.Data.squalr.icons .name -}}
+<svg ...>
+  {{ safeHTML (index .ctx.Site.Data.squalr.icons .name) }}
+</svg>
+{{- end -}}
+```
+
+## Adding the Projects section
+
+With the theme owned, adding a new content type was straightforward. Projects live in `content/projects/` as Markdown files with structured frontmatter:
+
+```yaml
+status: active
+repo: https://github.com/squalrus/merge-bot
+tech:
+  - GitHub Actions
+  - TypeScript
+```
+
+The list page renders a card grid. The detail page shows the project description plus a "Related posts" section — queried by finding all blog posts where `Params.projects` contains the current project's slug:
+
+```html
+{{- $slug := .File.ContentBaseName }}
+{{- $related := where site.RegularPages "Params.projects" "intersect" (slice $slug) }}
+```
+
+Blog posts reference projects the same way, in reverse:
+
+```yaml
+projects:
+  - merge-bot
+```
+
+Hugo looks up the project page and renders a card at the bottom of the post. Both directions work off the same frontmatter — no separate relationship table to maintain.
+
+## What I'd do differently
+
+The SCSS variable approach (injecting config values via `resources.ExecuteAsTemplate`) works, but it's a bit odd — you're treating SCSS as a Hugo template before compiling it. CSS custom properties defined in a `:root` block would be cleaner and easier to override. That's a refactor for another day.
+
+The theme also doesn't have open graph images per-post yet. Hugo has built-in OG support but generating post-specific images requires either a static image per post or a dynamic generation approach. Worth adding when there's content worth promoting.
+
+For now: zero npm, reproducible builds, a theme I can actually modify, and a Projects section that didn't require fighting an upstream dependency. Good enough to ship.

--- a/content/blog/modernizing-my-hugo-blog-in-2026.md
+++ b/content/blog/modernizing-my-hugo-blog-in-2026.md
@@ -1,0 +1,53 @@
+---
+title: "Modernizing My Hugo Blog in 2026"
+date: 2026-05-30T00:00:00+00:00
+tags:
+  - azure
+  - process
+  - website
+---
+
+My Google Analytics had been collecting zero data since July 2023.
+
+I didn't know that until I actually looked. The site loaded fine, posts rendered, nothing was obviously broken. But under the hood: Universal Analytics had been sunset for almost three years, the GitHub Actions deploy workflow was pinned to a `v0.0.1-preview` tag from 2019, Hugo was running on whatever version Azure felt like installing that day, and the theme was a git submodule I hadn't touched since 2021.
+
+## tldr;
+
+- Migrated from defunct Universal Analytics to GA4
+- Updated GitHub Actions from `v0.0.1-preview` to current stable versions
+- Pinned Hugo to a specific version
+- Replaced the m10c theme submodule with an owned custom theme
+- Added a Projects section
+- Fixed a few years of accumulated small issues
+
+## The audit
+
+I started with a simple goal: dust off the blog and start writing again. Before adding anything new I wanted to understand the actual state of the site.
+
+**Google Analytics**: The config had `UA-XXXXXXX` — a Universal Analytics property. Google shut that down in July 2023. The fix was straightforward (swap in a GA4 measurement ID and update the config format), but the CSP in `staticwebapp.config.json` also needed updating. GA4 loads from `googletagmanager.com` instead of `google-analytics.com`, so the allowed domains and inline script SHA both changed.
+
+**GitHub Actions**: The deploy workflow was using `Azure/static-web-apps-deploy@v0.0.1-preview` — a tag from the public preview in 2019. Also `actions/checkout@v2`, which runs on Node 16 (end of life). Neither would break immediately, but both are the kind of thing that stops working quietly one day.
+
+**Hugo version**: Nowhere specified. The workflow let Azure's Oryx builder pick whatever version it wanted. Local and CI builds could diverge silently, and there was no way to reproduce a specific build.
+
+**Theme**: m10c as a git submodule. Fine to set up initially, but I was depending on an upstream repo for every production build with no pinned commit.
+
+**Other**: Broken `<nft-card>` web components in the NFT post (the `embeddable-nfts` library is long abandoned), a Microsoft auth script in the base template that had no business being there, and a hardcoded `©2022` copyright year.
+
+## What got fixed
+
+**GA4**: Config updated to `services.googleAnalytics.id: G-XXXXXXXXXX`. CSP updated with the correct domains and a recomputed inline script SHA. Analytics are actually collecting data again.
+
+**GitHub Actions**: `actions/checkout` bumped to `v4`, Azure SWA deploy action to `v1`. Added an explicit Hugo install step using `peaceiris/actions-hugo@v3` with a pinned version. Added `.tool-versions` for local parity.
+
+**Custom theme**: Ported all of m10c's SCSS and HTML templates into `themes/squalr/` — a directory I own. Same layout, color palette, and components. One side effect: the Feather icons data file went from 53KB (400+ icons) to 2KB (nine icons actually in use).
+
+**Projects section**: Added `/projects/` with a card grid, detail pages, and cross-linking between posts and projects. A blog post can reference a project via frontmatter, and the project page lists related posts automatically.
+
+**Miscellaneous**: Removed the NFT embeds, the MS auth script, hardcoded copyright year (now dynamic), and dropped `opensea.io` and `unpkg.com` from the CSP.
+
+## Nothing visible changed
+
+Same layout, same posts, same URLs. The changes are all in the build pipeline, the ownership of the theme, and the analytics. But the site's in a better position to evolve — builds are reproducible, the theme is mine to modify, and adding a project is just a Markdown file.
+
+More posts coming.

--- a/content/blog/still-here-new-chapter.md
+++ b/content/blog/still-here-new-chapter.md
@@ -1,0 +1,35 @@
+---
+title: "Still Here. New Chapter."
+date: 2026-06-02T00:00:00+00:00
+tags:
+  - process
+---
+
+Three and a half years since my last post. The blog went quiet. A lot didn't.
+
+The last stretch at Microsoft was heads down — the azure.com team had grown into something significantly more complex than when I joined, and the work reflected that. Bigger features, more cross-team dependencies, more time thinking about how large engineering organizations function (and where they don't). I learned a lot. I also started to feel the pull toward something different.
+
+About a year ago I made the move. I left Microsoft after [N] years and joined [Dura Digital](https://duradigital.com) as a Sr Consultant.
+
+## What is Dura Digital
+
+[A few sentences about what Dura Digital does — who are the clients, what's the focus? Digital transformation? Azure migrations? Custom software? Fill this in.]
+
+The shift from being embedded in one large organization to working across multiple clients has been interesting. [What's different? The variety? The pace? The kind of problems?]
+
+## What I'm working on
+
+[This is where you get specific. What are you actually doing at Dura? Modernizing legacy systems? Building cloud infrastructure? Engineering process consulting? A mix? Concrete is more interesting than vague — "I spent three weeks untangling a deployment pipeline that hadn't been touched since 2017" is better than "I help clients modernize."]
+
+## What's coming here
+
+I've been meaning to get back to writing for a while. The excuses dried up when I finally modernized the blog itself (see the previous post) — new theme, fixed analytics, projects section. No more blaming the platform.
+
+Topics I'm planning to write about:
+
+- Azure and cloud infrastructure — my bread and butter for years, and still most of what I see in the field
+- Engineering process — estimation, documentation, how teams actually ship
+- Game dev — this is the growing personal interest I've been bad at writing about
+- Whatever I'm learning at Dura that I think is useful to share
+
+Good to be back.


### PR DESCRIPTION
Cleanup:
- Remove dead copyright field from config.yaml (sidebar renders year
  dynamically via the template; the config field was never evaluated)
- Add update note to the CSP post flagging the GA4 migration changes

Posts:
- modernizing-my-hugo-blog-in-2026.md (2026-05-30) — documents the
  tech stack audit and everything fixed: GA4, Actions, Hugo pin,
  custom theme, projects section
- still-here-new-chapter.md (2026-06-02, Tuesday) — comeback post,
  new role at Dura Digital; has a few bracketed TODOs for personal
  details to fill in before publishing
- building-a-custom-hugo-theme.md (2026-06-04, Thursday) — technical
  walkthrough of replacing m10c with the squalr theme: template
  hierarchy, SCSS pipeline, icon optimization, projects cross-linking

Posts dated in the future won't appear in the production build until
their date passes.

https://claude.ai/code/session_014JbWuPS8SdcPmXtTZT7oX5