### PR TITLE
Synthwave theme refresh

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -21,9 +21,9 @@ permalinks:
 
 params:
   author: 'Chad Schulz'
-  description: 'Sr Consultant at Dura Digital.'
+  description: 'Sr Consultant at Dura Digital. Prog metal, pixels, and questionable hotdog opinions.'
   avatar: '/img/bio.jpg'
-  menu_item_separator: '-'
+  menu_item_separator: '//'
   favicon: '/img/favicon.ico'
   images:
     - img/bio.jpg

--- a/themes/squalr/assets/css/_base.scss
+++ b/themes/squalr/assets/css/_base.scss
@@ -8,7 +8,7 @@ html {
 
 body {
   margin: 0;
-  font-family: sans-serif;
+  font-family: -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
   background: $dark-color;
   color: $light-color;
 }
@@ -19,18 +19,27 @@ h1, h2, h3, h4, h5, h6 {
 
 a {
   color: $primary-color;
-  transition: color 0.35s;
+  transition: color 0.35s, text-shadow 0.35s;
   text-decoration: none;
 
   &:hover {
     color: $lightest-color;
+    text-shadow: 0 0 12px rgba($primary-color, 0.6);
   }
 }
 
+hr {
+  border: none;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, $primary-color, $accent-color, transparent);
+  margin: 2rem 0;
+  opacity: 0.6;
+}
+
 code {
-  font-family: monospace,monospace;
+  font-family: ui-monospace, 'SFMono-Regular', Menlo, Monaco, Consolas, monospace;
   font-size: 1em;
-  color: rgba($light-color, .8);
+  color: rgba($primary-color, .85);
 }
 
 pre {
@@ -41,12 +50,13 @@ pre {
 
   code {
     font-size: .8em;
+    color: rgba($light-color, .9);
   }
 }
 
 ::selection {
-  background: rgba($light-color, .25);
+  background: rgba($primary-color, .25);
 }
 ::-moz-selection {
-  background: rgba($light-color, .25);
+  background: rgba($primary-color, .25);
 }

--- a/themes/squalr/assets/css/components/_app.scss
+++ b/themes/squalr/assets/css/components/_app.scss
@@ -2,13 +2,55 @@
   padding: 2.5em;
   background: $darkest-color;
   text-align: center;
+  position: relative;
+  overflow: hidden;
+
+  // Subtle scanline texture
+  &::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: repeating-linear-gradient(
+      0deg,
+      transparent,
+      transparent 2px,
+      rgba(0, 0, 0, 0.06) 2px,
+      rgba(0, 0, 0, 0.06) 4px
+    );
+    pointer-events: none;
+  }
+
+  // Accent line along the right edge (desktop) / bottom edge (mobile)
+  &::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 10%;
+    right: 10%;
+    height: 1px;
+    background: linear-gradient(90deg, transparent, $primary-color, $accent-color, transparent);
+    opacity: 0.5;
+  }
 }
 
 .app-header-avatar {
+  position: relative;
   width: 15rem;
   height: 15rem;
   border-radius: 100%;
-  border: 0.5rem solid $primary-color;
+  border: 0.35rem solid $primary-color;
+  box-shadow:
+    0 0 0 0.35rem $primary-color,
+    0 0 30px rgba($primary-color, 0.35),
+    0 0 60px rgba($primary-color, 0.12);
+  transition: box-shadow 0.4s;
+
+  &:hover {
+    box-shadow:
+      0 0 0 0.35rem $primary-color,
+      0 0 40px rgba($primary-color, 0.5),
+      0 0 80px rgba($primary-color, 0.2);
+  }
 }
 
 .app-container {
@@ -21,6 +63,13 @@
 
   a {
     margin: 0 0.1em;
+    transition: color 0.35s, filter 0.35s;
+
+    &:hover {
+      color: $primary-color;
+      filter: drop-shadow(0 0 6px rgba($primary-color, 0.7));
+      text-shadow: none;
+    }
   }
 }
 
@@ -28,15 +77,31 @@
   display: block;
   margin-top: 1.5rem;
   font-size: 0.7em;
-  color: rgba($light-color, 0.5);
+  color: rgba($light-color, 0.4);
+  letter-spacing: 0.05em;
 }
 
 .app-header-title {
-  color: $lightest-color;
   display: block;
   font-size: 2em;
   margin: 0.67em 0;
   font-weight: bold;
+  letter-spacing: -0.01em;
+  background: linear-gradient(160deg, $lightest-color 30%, $primary-color 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.app-header-menu {
+  font-size: 0.9em;
+  letter-spacing: 0.03em;
+
+  .app-header-menu-item {
+    &:hover {
+      text-shadow: 0 0 10px rgba($primary-color, 0.5);
+    }
+  }
 }
 
 @media (min-width: 940px) {
@@ -46,6 +111,17 @@
     left: 0;
     width: 20rem;
     min-height: 100vh;
+
+    // Right edge accent line on desktop
+    &::after {
+      top: 10%;
+      bottom: 10%;
+      left: auto;
+      right: 0;
+      width: 1px;
+      height: auto;
+      background: linear-gradient(180deg, transparent, $primary-color, $accent-color, transparent);
+    }
   }
 
   .app-container {

--- a/themes/squalr/assets/css/components/_post.scss
+++ b/themes/squalr/assets/css/components/_post.scss
@@ -1,5 +1,6 @@
 .post-title {
   color: $lightest-color;
+  letter-spacing: -0.02em;
 }
 
 .post-content {
@@ -13,11 +14,12 @@
   .highlight > div {
     border-left: 0.4em solid rgba($primary-color, .8);
     padding: 1em 1em;
+    background: $darkest-color;
   }
 
   blockquote {
-    border-left: 0.4em solid rgba($primary-color, .8);
-    margin: 1em 0em;
+    border-left: 0.4em solid $accent-color;
+    margin: 1em 0;
     padding: .5em 1em;
     background: $darkest-color;
 
@@ -26,11 +28,49 @@
     }
   }
 
+  h2 {
+    padding-bottom: 0.3em;
+    border-bottom: 1px solid rgba($primary-color, 0.25);
+    margin-top: 2rem;
+  }
+
+  h3 {
+    color: rgba($lightest-color, 0.85);
+  }
+
   img {
     max-width: 100%;
+    border-radius: 2px;
+  }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.9em;
+    margin: 1.5em 0;
+
+    th {
+      text-align: left;
+      padding: 0.5em 0.75em;
+      border-bottom: 2px solid rgba($primary-color, 0.4);
+      color: $primary-color;
+      font-size: 0.85em;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+    }
+
+    td {
+      padding: 0.5em 0.75em;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+    }
+
+    tr:last-child td {
+      border-bottom: none;
+    }
   }
 }
 
 .post-meta {
   font-size: 0.8em;
+  color: rgba($light-color, 0.7);
 }

--- a/themes/squalr/assets/css/components/_tag.scss
+++ b/themes/squalr/assets/css/components/_tag.scss
@@ -1,15 +1,20 @@
 .tag {
   display: inline-block;
   margin-right: 0.2em;
-  padding: 0 0.6em;
-  font-size: 0.9em;
+  padding: 0.1em 0.6em;
+  font-size: 0.85em;
   border-radius: 0.2em;
   white-space: nowrap;
-  background: rgba(255, 255, 255, 0.1);
-  transition: color 0.35s, background 0.35s;
+  background: rgba($primary-color, 0.1);
+  border: 1px solid rgba($primary-color, 0.2);
+  color: rgba($lightest-color, 0.85);
+  transition: background 0.25s, border-color 0.25s, color 0.25s, box-shadow 0.25s;
 
   &:hover {
-    transition: color 0.25s, background 0.05s;
-    background: rgba(255, 255, 255, 0.3);
+    background: rgba($primary-color, 0.2);
+    border-color: rgba($primary-color, 0.6);
+    color: $lightest-color;
+    box-shadow: 0 0 8px rgba($primary-color, 0.25);
+    text-shadow: none;
   }
 }

--- a/themes/squalr/assets/css/main.scss
+++ b/themes/squalr/assets/css/main.scss
@@ -3,6 +3,7 @@ $dark-color: {{ .Site.Params.style.darkColor | default "#353b43" }};
 $light-color: {{ .Site.Params.style.lightColor | default "#afbac4" }};
 $lightest-color: {{ .Site.Params.style.lightestColor | default "#ffffff" }};
 $primary-color: {{ .Site.Params.style.primaryColor | default "#52F0E0" }};
+$accent-color: #FF2D78;
 
 @import 'base';
 


### PR DESCRIPTION
Visual identity update leaning into the dark/neon aesthetic:

Sidebar:
- Subtle CSS scanline texture (repeating-linear-gradient overlay)
- Cyan→magenta gradient accent line on the right edge (desktop) / bottom edge (mobile)
- Site title: white→cyan gradient text
- Avatar: neon cyan glow (box-shadow), intensifies on hover
- Social icons: drop-shadow glow on hover
- Nav separator: '-' → '//'
- Bio updated with actual personality

Base:
- Font stack: system-ui/-apple-system stack instead of bare 'sans-serif'
- Inline code: cyan tint instead of muted gray
- Monospace: named stack (ui-monospace, SFMono-Regular, Menlo...)
- Link hover: text-shadow glow added
- hr: cyan→magenta gradient instead of default border
- ::selection: primary cyan tint instead of gray

Posts:
- H2: subtle cyan bottom border as section divider
- Blockquote: accent-color (magenta) left border instead of cyan — distinguishes quotes from code blocks visually
- Code blocks: darkest-color background explicitly set
- Tables: styled with cyan header text, uppercase labels
- Post title: tighter letter-spacing

Tags:
- Added border (cyan at 20% opacity) alongside background
- Hover: border brightens + box-shadow glow

https://claude.ai/code/session_014JbWuPS8SdcPmXtTZT7oX5