### PR TITLE
feat: live Last.fm now-playing widget with WinAmp skin (v1.1.0)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -45,16 +45,29 @@ Grouped by type; within each type sorted by ROI — small/high first, large/low 
 | --- | --- | --- |
 | Scheduled rebuild so future-dated posts auto-publish | S | M |
 | CSS-only gallery lightbox | S | M |
+| Windows minimize, maximize, and close | M | H |
 
 ### Improvements
 
 | Title | Effort | Value |
 | --- | --- | --- |
+| Add social icons | S | H |
+| Make 88×31 web badges configurable | S | M |
+| Verify reduced-motion coverage | S | M |
+| Self-host the three web fonts (drop the Google Fonts dependency) | S | M |
 | Mobile support pass | M | H |
 | Accessibility (a11y) support pass | M | H |
-| Self-host the three web fonts (drop the Google Fonts dependency) | S | M |
+| Re-write key copy (welcome, hero, status, badges, footer) | M | H |
+| Project showcase readability and CRT effect | M | H |
+| Rename "Field Notes" | S | L |
 | Flesh out the `desktop-tracker` project metadata | S | L |
-| TODO: review all blogs tags | | |
+| TODO: review all blog tags | | |
+
+### Cleanup
+
+| Title | Effort | Value |
+| --- | --- | --- |
+| Drop "web ring" concept | S | M |
 
 ---
 
@@ -103,6 +116,68 @@ Grouped by type; within each type sorted by ROI — small/high first, large/low 
 
 ---
 
+### Windows minimize, maximize, and close
+
+**Type:** feature
+
+**Why:** The Win95-style windows have decorative title bar buttons but they do nothing on click. Making them functional would be on-brand — minimize collapses a window to a taskbar entry, close hides it, maximize fills the viewport — and makes the homepage feel like an actual desktop rather than a static mockup.
+
+**Notes:**
+
+- Keep JS minimal: a small vanilla module that toggles classes. No framework.
+- **Minimize:** collapse the window to show only its title bar; add a taskbar entry at the bottom of the screen that restores it on click.
+- **Maximize:** expand the window to fill the main content area, storing original dimensions for restore. Double-click on the title bar is the classic trigger.
+- **Close:** hide the window entirely; add a way to reopen (a taskbar entry or a clickable "desktop icon").
+- Persist state in `sessionStorage` so windows stay closed/minimized across soft navigations but reset on a fresh visit.
+- JS goes in `themes/squalr/assets/js/` and is bundled through Hugo Pipes (same pattern as existing scripts).
+- Degrade gracefully with no JS — buttons just don't respond, same as today.
+
+---
+
+### Add social icons
+
+**Type:** improvement
+
+**Why:** Social links in the nav/sidebar are text-only. Recognizable platform icons (GitHub, LinkedIn, RSS) reduce cognitive load and look more polished — especially at compact nav widths.
+
+**Notes:**
+
+- Social links are defined in `config.yaml` under `params.social`. Each entry has `name` and `url`.
+- The theme renders them in the sidebar via the relevant partial in `themes/squalr/layouts/partials/`. Add inline SVG icons; keep them zero-dep (no icon font, no external sprite sheet).
+- Inline SVGs can live in a Hugo partial (`icon-github.html`, etc.) and be called with `{{ partial "icon-github" }}` where needed.
+- Size consistently with the existing pill/button chrome; apply the neon palette on hover.
+
+---
+
+### Make 88×31 web badges configurable
+
+**Type:** improvement
+
+**Why:** The 88×31 badge wall is hardcoded HTML — adding, removing, or reordering badges means editing a layout file. Moving them to a data file makes curation a one-line edit without touching templates.
+
+**Notes:**
+
+- Move badge definitions to `data/badges.yaml` — each entry: `label`, `img`, `url` (optional). Render via a Hugo `range` in the relevant partial/template.
+- Image files stay in `static/img/badges/` (or wherever they currently live). No structural change needed there.
+- Optional: add an `enabled: false` flag so a badge can be kept in the file but hidden without deleting it.
+
+---
+
+### Verify reduced-motion coverage
+
+**Type:** improvement
+
+**Why:** The site has several animations (rainbow wordmark, marquee, sparkle cursor, now-playing EQ bars, odometer roll, hover transitions). The a11y pass flags this as a goal but a standalone audit — `prefers-reduced-motion: reduce` on, then walk every page — confirms nothing slipped through.
+
+**Notes:**
+
+- Can be done as a sub-task of the [[accessibility-a11y-support-pass]] or standalone.
+- Method: DevTools → Rendering → "Emulate CSS media feature `prefers-reduced-motion`" → reduce. Walk the homepage, a blog post, and a project page. Anything still moving is a miss.
+- Known risks: the `huey` rainbow wordmark keyframes, the EQ "now spinning" bars, the odometer roll, the sparkle cursor trail, the marquee scroll, any CSS transitions on cards/buttons.
+- Each motion element should either stop entirely (`animation: none`) or swap to an instant/static state. Crossfades and instant reveals are acceptable; spinning, bouncing, and scrolling are not.
+
+---
+
 ### Self-host the three web fonts (drop the Google Fonts dependency)
 
 **Type:** improvement
@@ -115,21 +190,6 @@ Grouped by type; within each type sorted by ROI — small/high first, large/low 
 - Remove the Google Fonts `<link>` + preconnects from **both** `themes/squalr/layouts/index.html` and `themes/squalr/layouts/_default/baseof.html`, and drop `https://fonts.googleapis.com` / `font-src https://fonts.gstatic.com` from the CSP in `static/staticwebapp.config.json`.
 - Press Start 2P and VT323 are pixel/bitmap-ish and used at a few sizes — tight latin subsets keep them small.
 - Verify the A+ security headers score and that the wordmark / windows / terminals still render identically.
-
----
-
-### Flesh out the `desktop-tracker` project metadata
-
-**Type:** improvement
-
-**Why:** `content/projects/desktop-tracker.md` is the thinnest project — a one-line description, `Rust` / `Tauri` tech, and a faux-terminal banner, but no real body, no screenshots, and no detail worth landing on. It reads as a placeholder. Once the project has something to show, give it the metadata the card + detail page are built to display.
-
-**Notes:**
-
-- Add a real body (what it does, why local-first, the "watch what I'm actually doing" angle) so the detail page isn't empty.
-- Add a featured `image:` + a `gallery:` once there are screenshots — drop files in `static/img/projects/desktop-tracker/` (the folder exists).
-- Tighten `tech:` if the stack firms up, and flip `status:` off `wip` when it's real.
-- Cross-link any future "building desktop-tracker" post via `projects: [desktop-tracker]` so the card's field-note count lights up.
 
 ---
 
@@ -163,6 +223,82 @@ Grouped by type; within each type sorted by ROI — small/high first, large/low 
 - **Motion:** confirm `prefers-reduced-motion` covers _everything_ (the rainbow wordmark `huey` animation, now-spinning, the odometer roll), not just the obvious ones.
 - **Focus:** add visible `:focus-visible` styles for the nav buttons, links, and guestbook form (currently UA defaults), plus a skip-to-content link.
 - **Semantics:** mark the marquee `aria-hidden` (or give it a static fallback); give the visitor-counter odometer an accessible label; `aria-hidden` the decorative badges and custom cursor; add real `<label>`s to the guestbook inputs (placeholder-only today); verify heading order on each page type.
+
+---
+
+### Re-write key copy (welcome, hero, status, badges, footer)
+
+**Type:** improvement
+
+**Why:** The welcome message, hero subheading, now/status content, badge text, and footer copy were written quickly during the v1 build. They're the first things a visitor reads — they should sound like Chad, not like placeholder text.
+
+**Notes:**
+
+- See the Writing Style Guide in CLAUDE.md for voice reference: conversational, direct, self-aware, practical over theoretical.
+- Locations to hit:
+  - Homepage layout — the welcome blurb and hero subheading.
+  - The status/now section — what it says about current state and what Chad is working on.
+  - Footer — the sign-off copy and any flavor text.
+  - Badge alt text — small but worth making intentional.
+- This is a copywriting pass, not a structural change. One sitting with Chad's voice locked in. Don't touch layouts unless copy literally won't fit.
+
+---
+
+### Project showcase readability and CRT effect
+
+**Type:** improvement
+
+**Why:** The project cards and detail pages are functional but not memorable. Screenshots and faux-terminal snippets are the most visually interesting elements — a subtle CRT treatment (scanlines, phosphor glow, slight vignette) would make the showcase stand out and reinforce the retro aesthetic without touching the readability of prose.
+
+**Notes:**
+
+- CRT effect is pure CSS: a `::after` overlay with a `repeating-linear-gradient` for scanlines, an inset `box-shadow` for the vignette, and an optional subtle flicker via `@keyframes`. The flicker **must** respect `prefers-reduced-motion`.
+- Apply selectively to project screenshots and `.terminal` blocks — not to body text or UI chrome.
+- Readability pass is separate: check that the project list and detail pages have enough whitespace, contrast, and typographic hierarchy to scan quickly. The two goals (readable + standout) can conflict if the CRT is too heavy — keep the effect light.
+- Fun stretch: a "CRT on/off" toggle in the title bar would be on-brand for the 90s desktop theme and completely optional.
+
+---
+
+### Rename "Field Notes"
+
+**Type:** improvement
+
+**Why:** "Field Notes" doesn't quite land as a label for a personal dev/tech blog. A rename would better signal what the section is and match the voice of the rest of the site.
+
+**Notes:**
+
+- Open question: what should it be called? Candidates: **Blog**, **Posts**, **Devlog**, **Dispatch**, **Writing**, **Log**. Chad's call — this is a voice decision.
+- Touch points once decided: the nav label, any section heading on the homepage, and `config.yaml`. The URL slug is already `/blog/` — if the nav label is the only place "Field Notes" appears, the URL stays untouched and no redirect is needed.
+- Confirm with a grep for "Field Notes" across `themes/squalr/layouts/` and `config.yaml` before starting.
+
+---
+
+### Flesh out the `desktop-tracker` project metadata
+
+**Type:** improvement
+
+**Why:** `content/projects/desktop-tracker.md` is the thinnest project — a one-line description, `Rust` / `Tauri` tech, and a faux-terminal banner, but no real body, no screenshots, and no detail worth landing on. It reads as a placeholder. Once the project has something to show, give it the metadata the card + detail page are built to display.
+
+**Notes:**
+
+- Add a real body (what it does, why local-first, the "watch what I'm actually doing" angle) so the detail page isn't empty.
+- Add a featured `image:` + a `gallery:` once there are screenshots — drop files in `static/img/projects/desktop-tracker/` (the folder exists).
+- Tighten `tech:` if the stack firms up, and flip `status:` off `wip` when it's real.
+- Cross-link any future "building desktop-tracker" post via `projects: [desktop-tracker]` so the card's field-note count lights up.
+
+---
+
+### Drop "web ring" concept
+
+**Type:** cleanup
+
+**Why:** The web ring section is a fun nod to the 90s but it's not connected to an actual web ring and has no real outbound links. It reads as an empty placeholder that dilutes the page rather than adding personality.
+
+**Notes:**
+
+- Remove the web ring section from the homepage layout (`themes/squalr/layouts/index.html` or the relevant partial).
+- Remove any CSS scoped to `.webring` or similar from `cybershack.css`.
+- Don't leave a commented-out skeleton — if the concept ever comes back with real members and links, it's easy to add fresh.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 User-visible changes to squalr.us, newest first. Format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the site uses [semver](https://semver.org/) — see [BACKLOG.md](./BACKLOG.md#shipping-a-backlog-item) for how each backlog item gets versioned and migrated here.
 
+## [1.1.0] — 2026-06-01
+
+### Added
+
+- **Live "Now Spinning" powered by Last.fm.** The sidebar widget now fetches real listening data every 30 seconds — track name, artist, and album art. Shows `▶ playing` when something is actively playing, `■ last played` when idle. Spectrum bars drop flat when nothing is playing; falls back silently if the fetch fails. (`cybershack.js`, `index.html`)
+- **WinAmp 2.x skin for the now-playing widget.** The old static widget is reskinned as a WinAmp-style player: Win95 blue gradient title bar, black LCD with green phosphor text and an adaptive marquee (only scrolls when the title overflows), an 18-bar spectrum analyzer with staggered per-bar delays, beveled transport controls, and a decorative volume slider. (`cybershack.css`, `index.html`)
+
+---
+
 ## [1.0.0] — 2026-05-30
 
 The first versioned release — a years-overdue modernization, a full **90s GeoCities** redesign, and the backlog / changelog / versioning workflow the site now runs on. The [story is its own blog post](/2026/06/modernizing-my-hugo-blog-in-2026/).

--- a/themes/squalr/assets/css/cybershack.css
+++ b/themes/squalr/assets/css/cybershack.css
@@ -154,13 +154,86 @@ a:hover{ color:#fff; background:var(--hot); }
 .counter-wrap .lbl{ font-family:var(--term);font-size:18px;color:var(--hot) }
 .counter-wrap .since{ font-family:var(--comic);font-size:11px;color:var(--ink-2);margin-top:3px }
 
-/* now playing / status list */
-.npx{ font-family:var(--term);font-size:18px;color:var(--neon-2);text-align:center;line-height:1.25 }
-.npx .eq{ display:inline-flex;gap:2px;align-items:flex-end;height:16px;vertical-align:-3px;margin-right:6px }
-.npx .eq i{ width:3px;background:var(--neon);animation:eq .8s ease-in-out infinite }
-.npx .eq i:nth-child(2){ animation-delay:.15s } .npx .eq i:nth-child(3){ animation-delay:.3s } .npx .eq i:nth-child(4){ animation-delay:.45s }
-@keyframes eq{ 0%,100%{ height:4px } 50%{ height:16px } }
-.npx .song{ color:var(--ink);font-weight:700 } .npx .artist{ color:var(--hot) }
+/* ---- WinAmp now-playing widget ---- */
+.wa{ border:2px solid;border-color:var(--chrome-l) var(--chrome-dd) var(--chrome-dd) var(--chrome-l);overflow:hidden; }
+.wa-title{
+  display:flex;align-items:center;justify-content:space-between;gap:4px;
+  background:linear-gradient(90deg,var(--navy),#1084d0);
+  padding:3px 5px;
+}
+.wa-name{ font-family:var(--pix);font-size:10px;color:#fff;letter-spacing:.5px;flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap; }
+.wa-wbtns{ display:flex;gap:2px;flex-shrink:0; }
+.wa-wb{
+  width:14px;height:12px;padding:0;
+  border:1px solid;border-color:var(--chrome-l) var(--chrome-dd) var(--chrome-dd) var(--chrome-l);
+  background:var(--chrome);color:#000;
+  font-family:var(--comic);font-size:9px;line-height:1;font-weight:700;
+  cursor:pointer;display:flex;align-items:center;justify-content:center;
+}
+.wa-wb:active{ border-color:var(--chrome-dd) var(--chrome-l) var(--chrome-l) var(--chrome-dd); }
+.wa-body{ background:#232323;padding:4px; }
+
+/* LCD */
+.wa-lcd{
+  background:#000;padding:5px 6px 4px;margin-bottom:4px;
+  border:2px solid;border-color:var(--chrome-dd) var(--chrome-l) var(--chrome-l) var(--chrome-dd);
+}
+.wa-clip{ overflow:hidden;white-space:nowrap;height:20px;position:relative; }
+.wa-clip::before,.wa-clip::after{
+  content:'';position:absolute;top:0;bottom:0;width:8px;z-index:1;pointer-events:none;
+}
+.wa-clip::before{ left:0;background:linear-gradient(to right,#000,transparent); }
+.wa-clip::after { right:0;background:linear-gradient(to left, #000,transparent); }
+.wa-scroll{ display:inline-block;white-space:nowrap;color:#00ff66;font-family:var(--term);font-size:18px;line-height:1.1; }
+.wa-scroll.wa-scrolling{ animation:wa-scroll var(--wa-dur,12s) linear infinite;padding-right:var(--wa-pad,60px); }
+@keyframes wa-scroll{ 0%,20%{ transform:translateX(0) } 80%,100%{ transform:translateX(var(--wa-shift,-200px)) } }
+.wa-meta{ display:flex;justify-content:space-between;align-items:baseline;margin-top:3px;gap:4px; }
+.wa-state{ font-family:var(--term);font-size:14px;color:#00ff66;white-space:nowrap;flex-shrink:0; }
+.wa-state.last-played{ color:var(--fire); }
+.wa-who{ font-family:var(--term);font-size:14px;color:#005500;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;text-align:right; }
+
+/* spectrum */
+.wa-spec{
+  background:#000;padding:2px 3px;margin-bottom:4px;
+  border:2px solid;border-color:var(--chrome-dd) var(--chrome-l) var(--chrome-l) var(--chrome-dd);
+}
+.wa-spec .eq{ display:flex;gap:1px;align-items:flex-end;height:28px;width:100%; }
+.wa-spec .eq i{ flex:1;min-width:0;background:linear-gradient(to top,#00a619,#00ff44 70%,#ffcc00);animation:eq .8s ease-in-out infinite; }
+.wa-spec .eq i:nth-child(1) { animation-delay:0s;    animation-duration:.65s }
+.wa-spec .eq i:nth-child(2) { animation-delay:.04s;  animation-duration:.73s }
+.wa-spec .eq i:nth-child(3) { animation-delay:.09s;  animation-duration:.81s }
+.wa-spec .eq i:nth-child(4) { animation-delay:.15s;  animation-duration:.91s }
+.wa-spec .eq i:nth-child(5) { animation-delay:.22s;  animation-duration:.76s }
+.wa-spec .eq i:nth-child(6) { animation-delay:.29s;  animation-duration:.61s }
+.wa-spec .eq i:nth-child(7) { animation-delay:.36s;  animation-duration:.87s }
+.wa-spec .eq i:nth-child(8) { animation-delay:.43s;  animation-duration:.97s }
+.wa-spec .eq i:nth-child(9) { animation-delay:.49s;  animation-duration:.71s }
+.wa-spec .eq i:nth-child(10){ animation-delay:.52s;  animation-duration:.89s }
+.wa-spec .eq i:nth-child(11){ animation-delay:.46s;  animation-duration:.79s }
+.wa-spec .eq i:nth-child(12){ animation-delay:.39s;  animation-duration:.93s }
+.wa-spec .eq i:nth-child(13){ animation-delay:.31s;  animation-duration:.67s }
+.wa-spec .eq i:nth-child(14){ animation-delay:.24s;  animation-duration:.83s }
+.wa-spec .eq i:nth-child(15){ animation-delay:.17s;  animation-duration:.75s }
+.wa-spec .eq i:nth-child(16){ animation-delay:.11s;  animation-duration:.87s }
+.wa-spec .eq i:nth-child(17){ animation-delay:.05s;  animation-duration:.79s }
+.wa-spec .eq i:nth-child(18){ animation-delay:.01s;  animation-duration:.69s }
+@keyframes eq{ 0%,100%{height:2px} 50%{height:28px} }
+.wa-spec .eq.paused i{ animation:none;height:2px; }
+
+/* transport controls */
+.wa-ctrl{ display:flex;align-items:center;gap:3px; }
+.wa-cb{
+  padding:3px 5px;
+  border:1px solid;border-color:var(--chrome-l) var(--chrome-dd) var(--chrome-dd) var(--chrome-l);
+  background:var(--chrome);color:#000;
+  font-family:sans-serif;font-size:11px;line-height:1;
+  cursor:pointer;
+}
+.wa-cb:hover{ filter:brightness(1.08); }
+.wa-cb:active{ border-color:var(--chrome-dd) var(--chrome-l) var(--chrome-l) var(--chrome-dd); }
+.wa-play-btn{ color:#004d00; }
+.wa-vol{ flex:1;height:6px;background:#111;border:1px solid;border-color:var(--chrome-dd) var(--chrome-l) var(--chrome-l) var(--chrome-dd);margin-left:4px;position:relative; }
+.wa-vol-knob{ position:absolute;top:-4px;left:65%;width:6px;height:14px;background:var(--chrome);border:1px solid;border-color:var(--chrome-l) var(--chrome-dd) var(--chrome-dd) var(--chrome-l); }
 
 .statlist{ list-style:none;margin:0;padding:0;font-family:var(--term);font-size:18px }
 .statlist li{ display:flex;justify-content:space-between;gap:8px;align-items:center;
@@ -278,7 +351,7 @@ hr.candy{ height:6px;border:0;margin:14px 0;
   font-family:var(--term);font-size:14px;line-height:1;transform:translate(-50%,-50%);will-change:transform,opacity }
 
 @media (prefers-reduced-motion: reduce){
-  .mqbar > span, .rainbow, .npx .eq i, .blink{ animation:none }
+  .mqbar > span, .rainbow, .wa-spec .eq i, .wa-scroll, .blink{ animation:none }
 }
 
 /* ============================================================

--- a/themes/squalr/layouts/index.html
+++ b/themes/squalr/layouts/index.html
@@ -66,14 +66,42 @@
         <div class="since">online since Apr 20, 2021</div>
       </div>
 
-      <!-- now playing -->
-      <div class="panel">
-        <h3>♪ Now Spinning ♪</h3>
-        <div class="npx">
-          <span class="eq"><i></i><i></i><i></i><i></i></span>
-          <span class="song" id="np-song">The Dance of Eternity</span><br>
-          <span class="artist" id="np-artist">Dream Theater</span>
+      <!-- now playing (WinAmp) -->
+      <div class="wa">
+        <div class="wa-title">
+          <span class="wa-name">♫ WINAMP</span>
+          <div class="wa-wbtns">
+            <button class="wa-wb" title="minimize">_</button>
+            <button class="wa-wb" title="shade">□</button>
+            <button class="wa-wb" title="close">×</button>
+          </div>
         </div>
+        <div class="wa-body">
+          <div class="wa-lcd">
+            <div class="wa-clip">
+              <span class="wa-scroll" id="np-song">The Dance of Eternity</span>
+            </div>
+            <div class="wa-meta">
+              <span class="wa-state" id="np-label">▶ playing</span>
+              <span class="wa-who" id="np-artist">Dream Theater</span>
+            </div>
+          </div>
+          <div class="wa-spec">
+            <span class="eq" id="np-eq">
+              <i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i>
+              <i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i>
+            </span>
+          </div>
+          <div class="wa-ctrl">
+            <button class="wa-cb">⏮</button>
+            <button class="wa-cb wa-play-btn">▶</button>
+            <button class="wa-cb">⏸</button>
+            <button class="wa-cb">⏹</button>
+            <button class="wa-cb">⏭</button>
+            <div class="wa-vol"><div class="wa-vol-knob"></div></div>
+          </div>
+        </div>
+        <img id="np-art" src="" alt="" hidden>
       </div>
 
       <!-- status -->

--- a/themes/squalr/static/cybershack.js
+++ b/themes/squalr/static/cybershack.js
@@ -34,31 +34,77 @@
     });
   }
 
-  /* ---------- NOW SPINNING (rotates the prog-metal flex) ---------- */
-  var TRACKS = [
-    ['The Dance of Eternity', 'Dream Theater'],
-    ['Stream of Consciousness', 'Dream Theater'],
-    ['Bleed', 'Meshuggah'],
-    ['Cygnus....Vismund Cygnus', 'The Mars Volta'],
-    ['Cassandra Gemini', 'The Mars Volta'],
-    ['Schism', 'TOOL'],
-    ['Ghost of Perdition', 'Opeth'],
-    ['First Day of My Life... in 17/16', 'Glizzcore™']
-  ];
+  /* ---------- NOW SPINNING (Last.fm) ---------- */
+  var LFM_USER = 'squalrus';
+  var LFM_KEY  = 'eeb057078d22855ccfe801b9a69fba67';
   function initNowPlaying() {
-    var s = document.getElementById('np-song'),
-        a = document.getElementById('np-artist');
+    var s   = document.getElementById('np-song'),
+        a   = document.getElementById('np-artist'),
+        art = document.getElementById('np-art'),
+        eq  = document.getElementById('np-eq'),
+        lbl = document.getElementById('np-label');
     if (!s || !a) return;
-    var i = 0;
-    setInterval(function () {
-      i = (i + 1) % TRACKS.length;
+
+    function applyTrack(track) {
+      var isNow = !!(track['@attr'] && track['@attr'].nowplaying === 'true');
       s.style.opacity = 0; a.style.opacity = 0;
       setTimeout(function () {
-        s.textContent = TRACKS[i][0]; a.textContent = TRACKS[i][1];
+        s.textContent = track.name;
+        a.textContent = track.artist['#text'];
+        var imgs = track.image || [];
+        var src = '';
+        for (var j = imgs.length - 1; j >= 0; j--) {
+          if (imgs[j]['#text']) { src = imgs[j]['#text']; break; }
+        }
+        if (art) {
+          if (src) { art.src = src; art.alt = track.album['#text'] || track.name; art.hidden = false; }
+          else { art.hidden = true; }
+        }
+        if (eq)  { if (isNow) eq.classList.remove('paused'); else eq.classList.add('paused'); }
+        if (lbl) {
+          lbl.textContent = isNow ? '▶ playing' : '■ last played';
+          lbl.className = 'wa-state' + (isNow ? '' : ' last-played');
+        }
+        // Adaptive marquee: only scroll when text actually overflows the clip container
+        var wrap = s.parentElement;
+        if (wrap) {
+          s.classList.remove('wa-scrolling');
+          void s.offsetWidth; // flush so scrollWidth reflects new text without animation
+          var textW = s.scrollWidth;
+          var wrapW = wrap.clientWidth;
+          if (textW > wrapW) {
+            var gap = Math.max(60, wrapW >> 1); // half-container gap between loops
+            var shift = textW + gap;
+            s.style.setProperty('--wa-pad', gap + 'px');
+            s.style.setProperty('--wa-shift', '-' + shift + 'px');
+            // ~50px/s scroll speed; hold+gap take 40% of total
+            s.style.setProperty('--wa-dur', Math.max(7, shift / 50 / 0.6).toFixed(1) + 's');
+            s.classList.add('wa-scrolling');
+          } else {
+            s.style.removeProperty('--wa-pad');
+            s.style.removeProperty('--wa-shift');
+            s.style.removeProperty('--wa-dur');
+          }
+        }
         s.style.transition = a.style.transition = 'opacity .3s';
         s.style.opacity = 1; a.style.opacity = 1;
-      }, 300);
-    }, 4200);
+      }, 200);
+    }
+
+    function fetchLfm() {
+      fetch('https://ws.audioscrobbler.com/2.0/?method=user.getrecenttracks&user=' + LFM_USER + '&api_key=' + LFM_KEY + '&limit=1&format=json')
+        .then(function (r) { return r.json(); })
+        .then(function (data) {
+          var tracks = data.recenttracks && data.recenttracks.track;
+          if (!tracks) return;
+          var track = Array.isArray(tracks) ? tracks[0] : tracks;
+          if (track) applyTrack(track);
+        })
+        .catch(function () {});
+    }
+
+    fetchLfm();
+    setInterval(fetchLfm, 30000);
   }
 
   /* ---------- GUESTBOOK (localStorage) ---------- */


### PR DESCRIPTION
Replaces the hardcoded prog-metal track rotator with a live Last.fm fetch (user: squalrus, refreshes every 30s, fails silently). State label shows ▶ playing vs ■ last played; spectrum bars drop flat when nothing is active.

Widget reskinned as a WinAmp 2.x player: Win95 blue title bar, black LCD with green phosphor text and an adaptive marquee (only animates when the title actually overflows the clip container), 18-bar spectrum analyzer with staggered per-bar delays, beveled transport controls, and a decorative volume slider.

Also adds 9 new backlog items captured during this session.