### PR TITLE
fix: unblock Last.fm CSP + add now-playing to marquee bar (v1.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 User-visible changes to squalr.us, newest first. Format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the site uses [semver](https://semver.org/) — see [BACKLOG.md](./BACKLOG.md#shipping-a-backlog-item) for how each backlog item gets versioned and migrated here.
 
+## [1.2.0] — 2026-06-01
+
+### Added
+
+- **Now-playing in the marquee bar.** Both the homepage and inner-page marquees now show the live track from Last.fm — `▶ Song — Artist` while playing, `■ Song — Artist` when idle. Updates every 30 seconds alongside the WinAmp widget. (`cybershack.js`, `index.html`, `baseof.html`)
+
+### Fixed
+
+- **Last.fm fetch unblocked by CSP.** `https://ws.audioscrobbler.com` was missing from the `connect-src` directive, silently killing every now-playing fetch in the browser. Also added `https://lastfm.freetls.fastly.net` to `img-src` so album art loads without a CSP violation. (`staticwebapp.config.json`)
+
+---
+
 ## [1.1.0] — 2026-06-01
 
 ### Added

--- a/static/staticwebapp.config.json
+++ b/static/staticwebapp.config.json
@@ -14,7 +14,7 @@
     },
     "globalHeaders": {
         "cache-control": "must-revalidate, max-age=604800",
-        "content-security-policy": "default-src 'self' https://squalr.us; script-src 'self' https://www.googletagmanager.com 'sha256-oxuwTr/p2fGvScGQHZP8LD7bstjXkF6e0epKyE0nZvk=' https://platform.twitter.com https://gist.github.com; style-src 'self' https://squalr.us/ https://github.githubassets.com https://fonts.googleapis.com 'unsafe-inline'; font-src 'self' https://fonts.gstatic.com; frame-src https://platform.twitter.com; connect-src https://www.google-analytics.com https://www.googletagmanager.com; img-src 'self' data: https://www.google-analytics.com",
+        "content-security-policy": "default-src 'self' https://squalr.us; script-src 'self' https://www.googletagmanager.com 'sha256-oxuwTr/p2fGvScGQHZP8LD7bstjXkF6e0epKyE0nZvk=' https://platform.twitter.com https://gist.github.com; style-src 'self' https://squalr.us/ https://github.githubassets.com https://fonts.googleapis.com 'unsafe-inline'; font-src 'self' https://fonts.gstatic.com; frame-src https://platform.twitter.com; connect-src https://www.google-analytics.com https://www.googletagmanager.com https://ws.audioscrobbler.com; img-src 'self' data: https://www.google-analytics.com https://lastfm.freetls.fastly.net",
         "x-frame-options": "DENY"
     },
     "mimeTypes": {}

--- a/themes/squalr/assets/css/cybershack.css
+++ b/themes/squalr/assets/css/cybershack.css
@@ -48,7 +48,7 @@ body{
   image-rendering:pixelated;
   overflow-x:hidden;
 }
-img{image-rendering:pixelated;max-width:100%}
+img{image-rendering:pixelated;max-width:100%;display:block}
 
 /* custom pixel cursor (lime arrow w/ black outline — pops on light) */
 body, a, button{

--- a/themes/squalr/layouts/_default/baseof.html
+++ b/themes/squalr/layouts/_default/baseof.html
@@ -27,7 +27,7 @@
 </head>
 <body>
 
-<div class="mqbar"><span>★ {{ .Site.Title | upper }}'S CYBER-SHACK ★&nbsp;&nbsp; <b>YOU ARE HERE:</b> /{{ lower $sec }}/ &nbsp;&nbsp; <i>★ shipping since '21 ★</i> &nbsp;&nbsp; <u><a href="/#guestbook" style="color:inherit">SIGN MY GUESTBOOK ↓</a></u> &nbsp;&nbsp; ☣ best viewed in Netscape ☣ &nbsp;&nbsp; 🔊 volume UP! &nbsp;&nbsp;</span></div>
+<div class="mqbar"><span>★ {{ .Site.Title | upper }}'S CYBER-SHACK ★&nbsp;&nbsp; <b>YOU ARE HERE:</b> /{{ lower $sec }}/ &nbsp;&nbsp; <b>NOW PLAYING:</b> <span id="mq-track">loading...</span>&nbsp;&nbsp; <i>★ shipping since '21 ★</i> &nbsp;&nbsp; <u><a href="/#guestbook" style="color:inherit">SIGN MY GUESTBOOK ↓</a></u> &nbsp;&nbsp; ☣ best viewed in Netscape ☣ &nbsp;&nbsp; 🔊 volume UP! &nbsp;&nbsp;</span></div>
 
 <div class="page">
 

--- a/themes/squalr/layouts/index.html
+++ b/themes/squalr/layouts/index.html
@@ -29,7 +29,7 @@
 <body>
 
 <!-- ===== marquee ===== -->
-<div class="mqbar"><span>★ WELCOME 2 {{ .Site.Title | upper }}'S CYBER-SHACK ★&nbsp;&nbsp; <b>NOW PLAYING:</b> &nbsp;&nbsp; <i>YOU ARE VISITOR #00133742</i> &nbsp;&nbsp; <u>SIGN MY GUESTBOOK ↓</u> &nbsp;&nbsp; ☣ best viewed in Netscape Navigator ☣ &nbsp;&nbsp; 🔊 turn ur speakers on! &nbsp;&nbsp; ★ shipping since '21 ★ &nbsp;&nbsp;</span></div>
+<div class="mqbar"><span>★ WELCOME 2 {{ .Site.Title | upper }}'S CYBER-SHACK ★&nbsp;&nbsp; <b>NOW PLAYING:</b> <span id="mq-track">loading...</span>&nbsp;&nbsp; <i>YOU ARE VISITOR #00133742</i> &nbsp;&nbsp; <u>SIGN MY GUESTBOOK ↓</u> &nbsp;&nbsp; ☣ best viewed in Netscape Navigator ☣ &nbsp;&nbsp; 🔊 turn ur speakers on! &nbsp;&nbsp; ★ shipping since '21 ★ &nbsp;&nbsp;</span></div>
 
 <div class="page">
 

--- a/themes/squalr/static/cybershack.js
+++ b/themes/squalr/static/cybershack.js
@@ -42,11 +42,15 @@
         a   = document.getElementById('np-artist'),
         art = document.getElementById('np-art'),
         eq  = document.getElementById('np-eq'),
-        lbl = document.getElementById('np-label');
-    if (!s || !a) return;
+        lbl = document.getElementById('np-label'),
+        mq  = document.getElementById('mq-track');
+    var hasWidget = !!(s && a);
+    if (!hasWidget && !mq) return;
 
     function applyTrack(track) {
       var isNow = !!(track['@attr'] && track['@attr'].nowplaying === 'true');
+      if (mq) mq.textContent = (isNow ? '▶ ' : '■ ') + track.name + ' — ' + track.artist['#text'];
+      if (!hasWidget) return;
       s.style.opacity = 0; a.style.opacity = 0;
       setTimeout(function () {
         s.textContent = track.name;


### PR DESCRIPTION
- Add ws.audioscrobbler.com to connect-src and lastfm.freetls.fastly.net to img-src so the now-playing fetch and album art are no longer blocked
- Inject a live <span id="mq-track"> into both the homepage and inner-page marquees; cybershack.js updates it on every Last.fm poll (▶/■ Song — Artist)
- Inner pages (no WinAmp widget) now also show the live track in the marquee
- img { display:block } to eliminate inline baseline gap on images