### PR TITLE
improve: a11y pass + copy rewrite (v1.2.1)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -56,8 +56,6 @@ Grouped by type; within each type sorted by ROI — small/high first, large/low 
 | Verify reduced-motion coverage | S | M |
 | Self-host the three web fonts (drop the Google Fonts dependency) | S | M |
 | Mobile support pass | M | H |
-| Accessibility (a11y) support pass | M | H |
-| Re-write key copy (welcome, hero, status, badges, footer) | M | H |
 | Project showcase readability and CRT effect | M | H |
 | Rename "Field Notes" | S | L |
 | Flesh out the `desktop-tracker` project metadata | S | L |
@@ -207,40 +205,6 @@ Grouped by type; within each type sorted by ROI — small/high first, large/low 
 - Tap targets ≥44px on the nav buttons, webring links, and guestbook controls.
 - The sparkle cursor trail is `mousemove`-only — confirm it doesn't fire awkwardly on touch scroll.
 - Verify the visitor-counter odometer and the guestbook render cleanly in a narrow single column.
-
----
-
-### Accessibility (a11y) support pass
-
-**Type:** improvement
-
-**Why:** A clashing GeoCities palette plus decorative chrome (marquee, blink, rainbow text, custom cursor) is an accessibility minefield — contrast, motion, focus, and semantics all need a real audit. Some scaffolding exists (`prefers-reduced-motion` disables the marquee / blink / sparkle / eq animations; body prose is a high-contrast serif on cream), but nothing has been measured.
-
-**Notes:**
-
-- Baseline with Lighthouse / axe on the homepage, a blog post, a project page, and `/changelog`.
-- **Contrast:** check the worst offenders — lime `--neon` (`#00a619`) and teal on cream, the white-on-magenta link hover (`a:hover{color:#fff;background:var(--hot)}`), the green-on-black marquee, and the status pills. Darken whatever fails WCAG AA.
-- **Motion:** confirm `prefers-reduced-motion` covers _everything_ (the rainbow wordmark `huey` animation, now-spinning, the odometer roll), not just the obvious ones.
-- **Focus:** add visible `:focus-visible` styles for the nav buttons, links, and guestbook form (currently UA defaults), plus a skip-to-content link.
-- **Semantics:** mark the marquee `aria-hidden` (or give it a static fallback); give the visitor-counter odometer an accessible label; `aria-hidden` the decorative badges and custom cursor; add real `<label>`s to the guestbook inputs (placeholder-only today); verify heading order on each page type.
-
----
-
-### Re-write key copy (welcome, hero, status, badges, footer)
-
-**Type:** improvement
-
-**Why:** The welcome message, hero subheading, now/status content, badge text, and footer copy were written quickly during the v1 build. They're the first things a visitor reads — they should sound like Chad, not like placeholder text.
-
-**Notes:**
-
-- See the Writing Style Guide in CLAUDE.md for voice reference: conversational, direct, self-aware, practical over theoretical.
-- Locations to hit:
-  - Homepage layout — the welcome blurb and hero subheading.
-  - The status/now section — what it says about current state and what Chad is working on.
-  - Footer — the sign-off copy and any flavor text.
-  - Badge alt text — small but worth making intentional.
-- This is a copywriting pass, not a structural change. One sitting with Chad's voice locked in. Don't touch layouts unless copy literally won't fit.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 User-visible changes to squalr.us, newest first. Format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the site uses [semver](https://semver.org/) — see [BACKLOG.md](./BACKLOG.md#shipping-a-backlog-item) for how each backlog item gets versioned and migrated here.
 
+## [1.2.1] — 2026-06-01
+
+### Changed
+
+- **Accessibility pass (a11y).** Skip-to-main-content link on every page. Marquee, decorative title-bar chrome, badge wall, webring, flames, and sparkle cursor trail are all `aria-hidden`. `<nav>` with `aria-label` replaces the plain `<div class="navrow">`. `aria-current="page"` on the active nav link. WinAmp transport buttons removed from tab order. Guestbook inputs get real `<label>` elements (`.sr-only`). Visitor counter has an accessible `role="img"` label. Guestbook list and count are `aria-live="polite"`. WinAmp LCD is `aria-live` so now-playing updates announce to screen readers. Section stickers promoted from `<span>` to `<h2>`. Odometer roll animation skipped under `prefers-reduced-motion`. (`index.html`, `baseof.html`, `cybershack.css`, `cybershack.js`)
+- **Text contrast.** `--neon` darkened `#00a619` → `#007a14` and `--neon-2` darkened `#008b8b` → `#006e6e` — both now pass WCAG AA on cream and as white-text backgrounds. WinAmp artist color fixed from near-invisible `#005500` on black to readable `#50c050`. (`cybershack.css`)
+- **Focus styles.** Global `:focus-visible` ring (yellow outline) for keyboard navigation. (`cybershack.css`)
+- **Copy rewrite.** Welcome paragraph now introduces Chad by name and links [Dura Digital](https://duradigital.com). Hero tag links Dura Digital. Status panel adds "at Dura Digital" and drops the redundant post count. Footer drops the placeholder static-site-ring link; closing line simplified. (`index.html`, `baseof.html`)
+
+---
+
 ## [1.2.0] — 2026-06-01
 
 ### Added

--- a/config.yaml
+++ b/config.yaml
@@ -44,8 +44,7 @@ params:
   hero:
     kicker: '2026'
     lines:
-      - 'MY YEAR'
-      - 'OF {SHIPPING}.'
+      - '{SQUALRUS}'
     subtitle: 'Sr Consultant at Dura Digital. Building tools, breaking prod, {learning out loud}.'
     status: 'shipping'
     flavorChip: 'hotdogs/wk ∞'

--- a/themes/squalr/assets/css/cybershack.css
+++ b/themes/squalr/assets/css/cybershack.css
@@ -5,8 +5,8 @@
    Standalone homepage styles — not part of the main theme.
    ============================================================ */
 :root{
-  --neon:   #00a619;   /* lime, darkened for light bg */
-  --neon-2: #008b8b;   /* teal/cyan */
+  --neon:   #007a14;   /* lime — WCAG AA on cream (#fffdf2) and as bg w/ white text */
+  --neon-2: #006e6e;   /* teal — WCAG AA on cream and white */
   --hot:    #d4009c;   /* magenta */
   --zap:    #ffcc00;   /* yellow */
   --fire:   #ff6a00;   /* orange */
@@ -77,6 +77,29 @@ a:hover{ color:#fff; background:var(--hot); }
 .mqbar > span{ display:inline-block;padding-left:100%;animation:mq var(--mq) linear infinite; }
 @keyframes mq{ to{ transform:translateX(-100%) } }
 .mqbar b{ color:#ffe000 } .mqbar i{ color:#ff5fd2;font-style:normal } .mqbar u{ color:#33e0ff;text-decoration:none }
+
+/* ---------- accessibility helpers ---------- */
+/* skip-to-content link — hidden off-screen until focused */
+.skip-link{
+  position:absolute;top:-100%;left:0;z-index:9999;
+  background:var(--navy);color:#fff;
+  font-family:var(--pix);font-size:11px;
+  padding:10px 16px;text-decoration:none;
+}
+.skip-link:focus-visible{ top:0 }
+
+/* visually hidden but accessible */
+.sr-only{
+  position:absolute;width:1px;height:1px;padding:0;
+  margin:-1px;overflow:hidden;clip:rect(0,0,0,0);
+  white-space:nowrap;border:0;
+}
+
+/* keyboard focus ring (yellow = visible on all site backgrounds) */
+:focus-visible{
+  outline:3px solid var(--zap);
+  outline-offset:2px;
+}
 
 /* ---------- win95 bevels ---------- */
 .win{ margin:0 0 14px; }
@@ -190,7 +213,7 @@ a:hover{ color:#fff; background:var(--hot); }
 .wa-meta{ display:flex;justify-content:space-between;align-items:baseline;margin-top:3px;gap:4px; }
 .wa-state{ font-family:var(--term);font-size:14px;color:#00ff66;white-space:nowrap;flex-shrink:0; }
 .wa-state.last-played{ color:var(--fire); }
-.wa-who{ font-family:var(--term);font-size:14px;color:#005500;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;text-align:right; }
+.wa-who{ font-family:var(--term);font-size:14px;color:#50c050;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;text-align:right; }
 
 /* spectrum */
 .wa-spec{
@@ -352,7 +375,9 @@ hr.candy{ height:6px;border:0;margin:14px 0;
 
 @media (prefers-reduced-motion: reduce){
   .mqbar > span, .rainbow, .wa-spec .eq i, .wa-scroll, .blink{ animation:none }
+  /* odometer roll — JS reads this to skip the counting animation */
 }
+h2.sticker{ font-size:14px;font-weight:bold }
 
 /* ============================================================
    INNER PAGES (baseof) — garish chrome, READABLE content.

--- a/themes/squalr/layouts/_default/baseof.html
+++ b/themes/squalr/layouts/_default/baseof.html
@@ -27,28 +27,30 @@
 </head>
 <body>
 
-<div class="mqbar"><span>★ {{ .Site.Title | upper }}'S CYBER-SHACK ★&nbsp;&nbsp; <b>YOU ARE HERE:</b> /{{ lower $sec }}/ &nbsp;&nbsp; <b>NOW PLAYING:</b> <span id="mq-track">loading...</span>&nbsp;&nbsp; <i>★ shipping since '21 ★</i> &nbsp;&nbsp; <u><a href="/#guestbook" style="color:inherit">SIGN MY GUESTBOOK ↓</a></u> &nbsp;&nbsp; ☣ best viewed in Netscape ☣ &nbsp;&nbsp; 🔊 volume UP! &nbsp;&nbsp;</span></div>
+<a class="skip-link" href="#main-content">Skip to main content</a>
+
+<div class="mqbar" aria-hidden="true"><span>★ {{ .Site.Title | upper }}'S CYBER-SHACK ★&nbsp;&nbsp; <b>YOU ARE HERE:</b> /{{ lower $sec }}/ &nbsp;&nbsp; <b>NOW PLAYING:</b> <span id="mq-track">loading...</span>&nbsp;&nbsp; <i>★ shipping since '21 ★</i> &nbsp;&nbsp; <u><a href="/#guestbook" style="color:inherit" tabindex="-1">SIGN MY GUESTBOOK ↓</a></u> &nbsp;&nbsp; ☣ best viewed in Netscape ☣ &nbsp;&nbsp; 🔊 volume UP! &nbsp;&nbsp;</span></div>
 
 <div class="page">
 
-  <div class="banner-top banner-inner">
-    <a href="{{ .Site.BaseURL }}" class="home-link"><h1 class="wordmark"><span class="rainbow">{{ $lit }}</span><span style="color:var(--hot)">!!!</span></h1></a>
+  <div class="banner-inner banner-top">
+    <a href="{{ .Site.BaseURL }}" class="home-link"><h1 class="wordmark"><span class="rainbow">{{ $lit }}</span><span style="color:var(--hot)" aria-hidden="true">!!!</span></h1></a>
     <div class="tag">« <a href="{{ .Site.BaseURL }}">back to the cyber-shack</a> »</div>
-    <div class="flames"></div>
+    <div class="flames" aria-hidden="true"></div>
   </div>
 
-  <div class="navrow">
+  <nav class="navrow" aria-label="Main navigation">
     {{- range .Site.Menus.main }}
-    <a href="{{ .URL }}"{{ if and (ne .URL "/") (hasPrefix $.RelPermalink .URL) }} class="cur"{{ end }}>{{ .Name | upper }}</a>
+    <a href="{{ .URL }}"{{ if and (ne .URL "/") (hasPrefix $.RelPermalink .URL) }} class="cur" aria-current="page"{{ end }}>{{ .Name | upper }}</a>
     {{- end }}
     <a href="/#guestbook">GUESTBOOK</a>
-  </div>
+  </nav>
 
-  <main class="main">
+  <main class="main" id="main-content">
     <div class="win">
       <div class="tbar">
         <span>C:\{{ $sec }}\{{ .Title }}</span>
-        <span class="tb-btns"><i>_</i><i>▢</i><i>✕</i></span>
+        <span class="tb-btns" aria-hidden="true"><i>_</i><i>▢</i><i>✕</i></span>
       </div>
       <div class="body">
         {{ block "main" . }}{{ .Content }}{{ end }}
@@ -58,13 +60,13 @@
 
   <!-- footer -->
   <div class="foot">
-    <hr class="candy">
+    <hr class="candy" aria-hidden="true">
     {{- $version := "" }}{{ with findRE `\[\d+\.\d+\.\d+\]` (readFile "CHANGELOG.md") 1 }}{{ $version = replaceRE `[\[\]]` "" (index . 0) }}{{ end }}
     <div>✉ <a href="mailto:chad.awesome@gmail.com">email me</a> &nbsp;·&nbsp; <span class="em">[ © {{ now.Format "2006" }} {{ .Site.Params.author }} · /dev/null ]</span></div>
     <div style="margin-top:6px">⟢ <a href="/changelog/">CHANGELOG</a> · <a href="/backlog/">BACKLOG</a> · <a href="/#guestbook">GUESTBOOK</a> ⟢</div>
     <div class="updated">⟳ this page last updated {{ now.Format "01/02/2006" }} · Y2K compliant (probably)</div>
     {{- with $version }}<div class="ver"><a href="/changelog/">▓ running v{{ . }} ▓</a></div>{{ end }}
-    <div class="smol">Built with Hugo, caffeine, and <span class="made">too many neon glows</span>. ✨ &nbsp;|&nbsp; © Geocities is dead, long live Geocities.</div>
+    <div class="smol">Built with Hugo. ✨</div>
   </div>
 
 </div>

--- a/themes/squalr/layouts/index.html
+++ b/themes/squalr/layouts/index.html
@@ -28,56 +28,57 @@
 </head>
 <body>
 
+<a class="skip-link" href="#main-content">Skip to main content</a>
+
 <!-- ===== marquee ===== -->
-<div class="mqbar"><span>★ WELCOME 2 {{ .Site.Title | upper }}'S CYBER-SHACK ★&nbsp;&nbsp; <b>NOW PLAYING:</b> <span id="mq-track">loading...</span>&nbsp;&nbsp; <i>YOU ARE VISITOR #00133742</i> &nbsp;&nbsp; <u>SIGN MY GUESTBOOK ↓</u> &nbsp;&nbsp; ☣ best viewed in Netscape Navigator ☣ &nbsp;&nbsp; 🔊 turn ur speakers on! &nbsp;&nbsp; ★ shipping since '21 ★ &nbsp;&nbsp;</span></div>
+<div class="mqbar" aria-hidden="true"><span>★ WELCOME 2 {{ .Site.Title | upper }}'S CYBER-SHACK ★&nbsp;&nbsp; <b>NOW PLAYING:</b> <span id="mq-track">loading...</span>&nbsp;&nbsp; <i>YOU ARE VISITOR #00133742</i> &nbsp;&nbsp; <u>SIGN MY GUESTBOOK ↓</u> &nbsp;&nbsp; ☣ best viewed in Netscape Navigator ☣ &nbsp;&nbsp; 🔊 turn ur speakers on! &nbsp;&nbsp; ★ shipping since '21 ★ &nbsp;&nbsp;</span></div>
 
 <div class="page">
 
   <!-- ===== top banner ===== -->
   <div class="banner-top">
-    <div class="eyebrow">·:¦:· HOME OF ·:¦:·</div>
-    <h1 class="wordmark"><span class="rainbow">SQUALRUS</span><span style="color:var(--hot)">!!!</span></h1>
-    <div class="tag">a Sr Consultant @ Dura Digital · prog metal · pixels · <span class="hi">strong opinions about whitespace</span></div>
-    <div class="speakers">♫ ♪ this page sounds best with the volume UP ♪ ♫</div>
-    <div class="constr">
+    <div class="eyebrow" aria-hidden="true">·:¦:· HOME OF ·:¦:·</div>
+    <h1 class="wordmark"><span class="rainbow">{{$lit}}</span><span style="color:var(--hot)" aria-hidden="true">!!!</span></h1>
+    <div class="tag">Sr Consultant @ <a href="https://duradigital.com">Dura Digital</a> · music · pixels · <span class="hi">strong opinions about whitespace</span></div>
+    <div class="constr" aria-hidden="true">
       <span class="digger">⛏</span> <span class="txt">UNDER CONSTRUCTION SINCE 2001</span> <span class="digger">🚧</span>
     </div>
-    <div class="flames"></div>
+    <div class="flames" aria-hidden="true"></div>
   </div>
 
   <!-- ===== nav ===== -->
-  <div class="navrow">
+  <nav class="navrow" aria-label="Main navigation">
     {{- range .Site.Menus.main }}
-    <a href="{{ .URL }}"{{ if eq .URL "/" }} class="cur"{{ end }}>{{ .Name | upper }}</a>
+    <a href="{{ .URL }}"{{ if eq .URL "/" }} class="cur" aria-current="page"{{ end }}>{{ .Name | upper }}</a>
     {{- end }}
     <a href="#guestbook">GUESTBOOK</a>
-  </div>
+  </nav>
 
   <div class="cols">
 
     <!-- ============ SIDEBAR ============ -->
-    <aside class="side">
+    <aside class="side" aria-label="Sidebar">
 
       <!-- visitor counter -->
       <div class="panel counter-wrap">
         <h3>★ Visitors ★</h3>
-        <div class="odo" id="odo"></div>
-        <div class="lbl">U R VISITOR!</div>
+        <div class="odo" id="odo" role="img" aria-label="Visitor count"></div>
+        <div class="lbl" aria-hidden="true">U R VISITOR!</div>
         <div class="since">online since Apr 20, 2021</div>
       </div>
 
       <!-- now playing (WinAmp) -->
-      <div class="wa">
+      <div class="wa" aria-label="Now playing">
         <div class="wa-title">
-          <span class="wa-name">♫ WINAMP</span>
-          <div class="wa-wbtns">
-            <button class="wa-wb" title="minimize">_</button>
-            <button class="wa-wb" title="shade">□</button>
-            <button class="wa-wb" title="close">×</button>
+          <span class="wa-name" aria-hidden="true">♫ WINAMP</span>
+          <div class="wa-wbtns" aria-hidden="true">
+            <button class="wa-wb" tabindex="-1">_</button>
+            <button class="wa-wb" tabindex="-1">□</button>
+            <button class="wa-wb" tabindex="-1">×</button>
           </div>
         </div>
         <div class="wa-body">
-          <div class="wa-lcd">
+          <div class="wa-lcd" aria-live="polite" aria-atomic="true">
             <div class="wa-clip">
               <span class="wa-scroll" id="np-song">The Dance of Eternity</span>
             </div>
@@ -86,18 +87,18 @@
               <span class="wa-who" id="np-artist">Dream Theater</span>
             </div>
           </div>
-          <div class="wa-spec">
+          <div class="wa-spec" aria-hidden="true">
             <span class="eq" id="np-eq">
               <i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i>
               <i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i>
             </span>
           </div>
-          <div class="wa-ctrl">
-            <button class="wa-cb">⏮</button>
-            <button class="wa-cb wa-play-btn">▶</button>
-            <button class="wa-cb">⏸</button>
-            <button class="wa-cb">⏹</button>
-            <button class="wa-cb">⏭</button>
+          <div class="wa-ctrl" aria-hidden="true">
+            <button class="wa-cb" tabindex="-1">⏮</button>
+            <button class="wa-cb wa-play-btn" tabindex="-1">▶</button>
+            <button class="wa-cb" tabindex="-1">⏸</button>
+            <button class="wa-cb" tabindex="-1">⏹</button>
+            <button class="wa-cb" tabindex="-1">⏭</button>
             <div class="wa-vol"><div class="wa-vol-knob"></div></div>
           </div>
         </div>
@@ -109,57 +110,56 @@
         <h3>:: Status ::</h3>
         <ul class="statlist">
           <li><span>currently</span> <b class="on">shipping ▸</b></li>
-          <li><span>projects live</span> <b>{{ len $projects }}</b></li>
-          <li><span>field notes</span> <b>{{ len $posts }}</b></li>
+          <li><span>at</span> <b><a href="https://duradigital.com">Dura Digital</a></b></li>
+          <li><span>projects</span> <b>{{ len $projects }}</b></li>
           <li><span>coffee level</span> <b class="wip">critical</b></li>
-          <li><span>fav time sig</span> <b>7/8</b></li>
         </ul>
       </div>
 
       <!-- web badges -->
       <div class="panel">
         <h3>« proudly served »</h3>
-        <div class="badges">
-          <a href="#" class="badge88 b-netscape">best viewed in<br><b>NETSCAPE</b></a>
-          <a href="#" class="badge88 b-1024">made 4<br><b>1024×768</b></a>
-          <a href="#" class="badge88 b-hugo">built with<br><b>HUGO</b></a>
-          <a href="#" class="badge88 b-html">valid<br><b>HTML 4.01</b></a>
-          <a href="#" class="badge88 b-noai">100%<br><b>HAND-CODED</b></a>
-          <a href="#" class="badge88 b-award">COOL SITE<br><b>of the DAY</b></a>
+        <div class="badges" aria-hidden="true">
+          <a href="#" class="badge88 b-netscape" tabindex="-1">best viewed in<br><b>NETSCAPE</b></a>
+          <a href="#" class="badge88 b-1024" tabindex="-1">made 4<br><b>1024×768</b></a>
+          <a href="#" class="badge88 b-hugo" tabindex="-1">built with<br><b>HUGO</b></a>
+          <a href="#" class="badge88 b-html" tabindex="-1">valid<br><b>HTML 4.01</b></a>
+          <a href="#" class="badge88 b-noai" tabindex="-1">100%<br><b>HAND-CODED</b></a>
+          <a href="#" class="badge88 b-award" tabindex="-1">COOL SITE<br><b>of the DAY</b></a>
         </div>
       </div>
 
       <!-- webring -->
-      <div class="panel webring">
+      <div class="panel webring" aria-hidden="true">
         <h3>The Static-Site Ring</h3>
         this site is node #14 in a<br>ring of Hugo webmasters
         <div class="nav">
-          <a href="#">◀ PREV</a>
-          <a href="#">RANDOM</a>
-          <a href="#">NEXT ▶</a>
+          <a href="#" tabindex="-1">◀ PREV</a>
+          <a href="#" tabindex="-1">RANDOM</a>
+          <a href="#" tabindex="-1">NEXT ▶</a>
         </div>
       </div>
 
     </aside>
 
     <!-- ============ MAIN ============ -->
-    <main class="main">
+    <main class="main" id="main-content">
 
       <!-- welcome window -->
       <div class="win">
         <div class="tbar">
           <span>C:\SQUALRUS\welcome.exe</span>
-          <span class="tb-btns"><i>_</i><i>▢</i><i>✕</i></span>
+          <span class="tb-btns" aria-hidden="true"><i>_</i><i>▢</i><i>✕</i></span>
         </div>
         <div class="body welcome">
-          <p><b class="pop">Hiya, websurfer!</b> 🏄 You've reached the personal homepage of <b class="pop">{{ .Site.Params.author }}</b> — Sr Consultant by day, pixel-pusher &amp; <span class="hi">prog-metal evangelist</span> by night.</p>
-          <p>This is <b>squalr.us</b>: a hand-built Hugo site with too many neon glows, zero whitespace, and a deep, abiding disrespect for the year being 2026. Grab a Surge, dim the lights, and <a href="#guestbook">sign the guestbook</a> before you bounce.</p>
+          <p><b class="pop">Hey! I'm Chad.</b> 🏄 Sr Consultant at <a href="https://duradigital.com">Dura Digital</a> — helping teams ship real products for real people. Off the clock I build things that make me happy and teach me something along the way. Usually both.</p>
+          <p><b>squalr.us</b> is my corner of the internet: built with Hugo, stuck in 1997, and fueled by caffeine and music. <a href="#guestbook">Sign the guestbook</a> before you leave — don't be a lurker.</p>
         </div>
       </div>
 
       <!-- ===== PROJECTS ===== -->
       <div id="projects">
-        <span class="sticker">▰ MY RAD PROJECTS</span>
+        <h2 class="sticker">▰ MY RAD PROJECTS</h2>
         <div class="projgrid">
           {{- range sort $projects "Params.weight" }}
           {{ partial "pcard.html" . }}
@@ -167,11 +167,11 @@
         </div>
       </div>
 
-      <hr class="candy">
+      <hr class="candy" aria-hidden="true">
 
       <!-- ===== RECENT POSTS ===== -->
       <div id="posts">
-        <span class="sticker">▤ FIELD NOTES</span>
+        <h2 class="sticker">▤ FIELD NOTES</h2>
         <ul class="posts">
           {{- range first 5 $posts }}
           {{ partial "post-li.html" (dict "page" .) }}
@@ -179,39 +179,42 @@
         </ul>
       </div>
 
-      <hr class="candy">
+      <hr class="candy" aria-hidden="true">
 
       <!-- ===== GUESTBOOK ===== -->
       <div id="guestbook" class="win">
         <div class="tbar">
           <span>★ SIGN MY GUESTBOOK ★</span>
-          <span class="tb-btns"><i>_</i><i>▢</i><i>✕</i></span>
+          <span class="tb-btns" aria-hidden="true"><i>_</i><i>▢</i><i>✕</i></span>
         </div>
         <div class="body">
-          <div style="font-family:var(--term);font-size:18px;color:var(--neon-2);text-align:center;margin-bottom:10px">don't be a lurker — leave a mark! ✍</div>
+          <div style="font-family:var(--term);font-size:18px;color:var(--neon-2);text-align:center;margin-bottom:10px" aria-hidden="true">don't be a lurker — leave a mark! ✍</div>
           <form class="gb-form" id="gb-form" autocomplete="off">
             <div class="gb-row">
+              <label for="gb-name" class="sr-only">Name or handle</label>
               <input class="name-in" id="gb-name" maxlength="32" placeholder="yer name / handle" />
+              <label for="gb-mood" class="sr-only">Mood (optional)</label>
               <input class="mood-in" id="gb-mood" maxlength="14" placeholder="mood (☺)" />
             </div>
+            <label for="gb-msg" class="sr-only">Message</label>
             <textarea id="gb-msg" maxlength="240" placeholder="say something rad..."></textarea>
             <div><button class="gb-send" type="submit">»» STAMP IT ««</button></div>
           </form>
-          <div class="gb-list" id="gb-list"></div>
-          <div class="gb-count" id="gb-count"></div>
+          <div class="gb-list" id="gb-list" aria-live="polite" aria-label="Guestbook entries"></div>
+          <div class="gb-count" id="gb-count" aria-live="polite"></div>
           <div style="font-family:var(--comic);font-size:11px;color:var(--ink-2);text-align:center;margin-top:8px">(entries save to your own browser — it's a 90s tribute, not a server 😉)</div>
         </div>
       </div>
 
       <!-- footer -->
       <div class="foot">
-        <hr class="candy">
+        <hr class="candy" aria-hidden="true">
         <div>✉ <a href="mailto:chad.awesome@gmail.com">email me</a> &nbsp;·&nbsp; <span class="em">[ © {{ now.Format "2006" }} {{ .Site.Params.author }} · /dev/null ]</span></div>
-        <div style="margin-top:6px">⟢ <a href="/changelog/">CHANGELOG</a> · <a href="/backlog/">BACKLOG</a> · <a href="#">STATIC-SITE RING</a> ⟢</div>
+        <div style="margin-top:6px">⟢ <a href="/changelog/">CHANGELOG</a> · <a href="/backlog/">BACKLOG</a> ⟢</div>
         <div class="updated">⟳ this page last updated {{ now.Format "01/02/2006" }} · Y2K compliant (probably)</div>
         {{- $version := "" }}{{ with findRE `\[\d+\.\d+\.\d+\]` (readFile "CHANGELOG.md") 1 }}{{ $version = replaceRE `[\[\]]` "" (index . 0) }}{{ end }}
         {{- with $version }}<div class="ver"><a href="/changelog/">▓ running v{{ . }} ▓</a></div>{{ end }}
-        <div class="smol">Built with Hugo, caffeine, and <span class="made">too many neon glows</span>. ✨ &nbsp;|&nbsp; © Geocities is dead, long live Geocities.</div>
+        <div class="smol">Built with Hugo. ✨</div>
       </div>
 
     </main>

--- a/themes/squalr/static/cybershack.js
+++ b/themes/squalr/static/cybershack.js
@@ -8,6 +8,7 @@
   /* ---------- VISITOR COUNTER (odometer) ---------- */
   // Persists per-browser via localStorage; seeded with a fake "you're the
   // 133,742nd visitor" base so it always looks impressively well-trafficked.
+  var reducedMotion = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
   function initCounter() {
     var odo = document.getElementById('odo');
     if (!odo) return;
@@ -21,9 +22,13 @@
     str.split('').forEach(function (ch, i) {
       var d = document.createElement('span');
       d.className = 'd';
-      d.textContent = '0';
       odo.appendChild(d);
+      if (reducedMotion) {
+        d.textContent = ch;
+        return;
+      }
       // little roll-up animation
+      d.textContent = '0';
       var target = parseInt(ch, 10);
       var step = 0;
       var iv = setInterval(function () {
@@ -181,7 +186,7 @@
   var trailOn = true;
   var lastSpawn = 0;
   function initSparkles() {
-    if (window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+    if (reducedMotion) return;
     window.addEventListener('mousemove', function (e) {
       if (!trailOn) return;
       var now = Date.now();
@@ -189,6 +194,7 @@
       lastSpawn = now;
       var s = document.createElement('div');
       s.className = 'spark';
+      s.setAttribute('aria-hidden', 'true');
       s.textContent = GLYPHS[(Math.random() * GLYPHS.length) | 0];
       var hue = (Math.random() * 360) | 0;
       s.style.color = 'hsl(' + hue + ',100%,65%)';


### PR DESCRIPTION
Accessibility:
- Skip-to-main-content link on every page
- Marquee, decorative chrome, badges, webring, flames aria-hidden
- <nav aria-label> + aria-current="page" on active link
- Guestbook inputs get real <label class="sr-only"> elements
- WinAmp transport buttons removed from tab order; LCD is aria-live
- Visitor counter gets role="img" + aria-label
- Section stickers promoted from <span> to <h2>
- Global :focus-visible ring (yellow) for keyboard nav
- --neon darkened #00a619 -> #007a14 (WCAG AA, 5.5:1 on cream)
- --neon-2 darkened #008b8b -> #006e6e (WCAG AA, 6.1:1)
- WinAmp artist color fixed #005500 -> #50c050 (readable on black)
- Odometer roll skips under prefers-reduced-motion
- Sparkle elements get aria-hidden="true"

Copy:
- Fix wordmark: was hardcoded SQUALRUS, now uses {{$lit}} from config
- config.yaml hero.lines updated to {SQUALRUS} so wordmark is config-driven
- Welcome paragraph: direct intro, links Dura Digital, matches voice
- Hero tag + welcome: "prog metal" -> "music"; "hand-built" -> "built"
- Status panel: adds "at Dura Digital", removes fav-time-sig row
- Remove speakers banner from hero
- Footer: drop static-site-ring link; remove Geocities closer; simplify