### PR TITLE
fix: a11y violations, CSP hash, mobile overflow + content/docs (v1.3.1)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -39,6 +39,12 @@ Grouped by type; within each type sorted by ROI — small/high first, large/low 
 - **Effort** — rough Claude session cost. **S** = a single focused turn (one or two files, no clarification needed). **M** = a conversation session (several files, maybe a question or two upfront, fits one context window). **L** = multi-session work that warrants a written plan first.
 - **Value** — impact on a reader/visitor. **H** = clearly noticeable or removes real friction. **M** = a solid improvement, narrower audience. **L** = polish or quiet upkeep.
 
+### Bugs
+
+| Title | Effort | Value |
+| --- | --- | --- |
+| Color contrast failures across cards and badges (a11y) | M | H |
+
 ### Features
 
 | Title | Effort | Value |
@@ -52,7 +58,13 @@ Grouped by type; within each type sorted by ROI — small/high first, large/low 
 | Title | Effort | Value |
 | --- | --- | --- |
 | Project showcase readability and CRT effect | M | H |
-| Flesh out the `desktop-tracker` project metadata | S | L |
+| Flesh out the `desktop-tracker` project body and screenshots | S | M |
+| Add preconnect hints for Last.fm and audioscrobbler | S | M |
+| Explicit width and height on Now Playing album art | S | M |
+| Defer cybershack.js from critical render path | S | M |
+| Defer Google Tag Manager loading | S | M |
+| Serve responsive / optimized images (Glizzy Relay) | M | M |
+| Fix forced reflow in cybershack.js | M | M |
 
 ### Cleanup
 
@@ -141,17 +153,16 @@ Grouped by type; within each type sorted by ROI — small/high first, large/low 
 
 ---
 
-### Flesh out the `desktop-tracker` project metadata
+### Flesh out the `desktop-tracker` project body and screenshots
 
 **Type:** improvement
 
-**Why:** `content/projects/desktop-tracker.md` is the thinnest project — a one-line description, `Rust` / `Tauri` tech, and a faux-terminal banner, but no real body, no screenshots, and no detail worth landing on. It reads as a placeholder. Once the project has something to show, give it the metadata the card + detail page are built to display.
+**Why:** Metadata was updated in v1.3.1 (correct stack, real description, status promoted to `active`) but the detail page still has no body copy and no screenshots. Without them, clicking into the project lands on an empty shell.
 
 **Notes:**
 
-- Add a real body (what it does, why local-first, the "watch what I'm actually doing" angle) so the detail page isn't empty.
+- Add a real body (what the app does, why Virtual Desktop tracking, how the BambooHR sync works) so the detail page isn't empty.
 - Add a featured `image:` + a `gallery:` once there are screenshots — drop files in `static/img/projects/desktop-tracker/` (the folder exists).
-- Tighten `tech:` if the stack firms up, and flip `status:` off `wip` when it's real.
 - Cross-link any future "building desktop-tracker" post via `projects: [desktop-tracker]` so the card's field-note count lights up.
 
 ---
@@ -182,6 +193,125 @@ Grouped by type; within each type sorted by ROI — small/high first, large/low 
 - Remove the web ring section from the homepage layout (`themes/squalr/layouts/index.html` or the relevant partial).
 - Remove any CSS scoped to `.webring` or similar from `cybershack.css`.
 - Don't leave a commented-out skeleton — if the concept ever comes back with real members and links, it's easy to add fresh.
+
+---
+
+### Color contrast failures across cards and badges (a11y)
+
+**Type:** bug
+
+**Why:** Multiple elements fail WCAG AA contrast requirements (4.5:1 for normal text, 3:1 for large/bold text). Low-contrast text is difficult or impossible to read for users with low vision or color-vision deficiency.
+
+**Notes:**
+
+- Failing elements identified by Lighthouse:
+  - `.wip` badge text (status pill)
+  - `.panel` div text
+  - `.pnotes.none` span ("◇ no notes yet")
+  - `.pcard` article background/foreground
+  - `.pstat.archived` badge text
+- All styles live in `themes/squalr/assets/css/cybershack.css`. Check each selector's `color` and `background-color` with a contrast checker (browser DevTools has one built in under the color picker).
+- The 90s GeoCities aesthetic uses pastels and neons that often fail WCAG — adjust luminance rather than hue to preserve the vibe while hitting contrast ratios.
+- `.pnotes.none` is the "no notes yet" placeholder — easiest fix is darkening the text color since the background is already known.
+- Badge fixes (`.wip`, `.pstat.archived`): try darkening the text or lightening the background by 10–15% and re-check; small adjustments usually clear the threshold without visible aesthetic change.
+
+---
+
+### Add preconnect hints for Last.fm and audioscrobbler
+
+**Type:** improvement
+
+**Why:** Lighthouse estimates 330ms LCP savings from preconnecting to `https://lastfm.freetls.fastly.net` and 200ms from `https://ws.audioscrobbler.com`. These origins serve the Now Playing widget's album art and API data. Adding `<link rel="preconnect">` lets the browser start DNS/TLS handshakes before the JS fires the requests.
+
+**Notes:**
+
+- Add to the `<head>` in `themes/squalr/layouts/index.html` (homepage only — that's where Now Playing lives):
+
+  ```html
+  <link rel="preconnect" href="https://lastfm.freetls.fastly.net" crossorigin>
+  <link rel="preconnect" href="https://ws.audioscrobbler.com">
+  ```
+
+- Keep total preconnect hints to ≤4 per Lighthouse guidance. These two are the highest-value targets.
+- Pair with deferring `cybershack.js` (see separate item) for cumulative LCP improvement — preconnect only helps if the fetch itself isn't also blocked by a render-blocking script.
+- The `crossorigin` attribute is needed for `lastfm.freetls.fastly.net` because the `<img>` fetch is CORS; omit it for the audioscrobbler XHR (same-origin CORS semantics differ).
+
+---
+
+### Explicit width and height on Now Playing album art
+
+**Type:** improvement
+
+**Why:** The Last.fm album art `<img id="np-art">` has no explicit `width` or `height` attributes, so the browser can't reserve space for it before the image loads. This causes layout shift (CLS) — surrounding content jumps when the image arrives.
+
+**Notes:**
+
+- The image is fetched dynamically from Last.fm's CDN at 300×300 resolution.
+- Add `width="300" height="300"` to the `<img id="np-art">` element — either in the template where it's declared or in the JS where the element is created/populated in `themes/squalr/static/cybershack.js`.
+- CSS can still override the displayed size; the attributes just give the browser an aspect ratio to hold space with.
+- If the Now Playing widget is hidden when no track is playing, the reserved space disappears anyway — confirm the hiding/showing logic doesn't itself cause layout shift.
+
+---
+
+### Defer cybershack.js from critical render path
+
+**Type:** improvement
+
+**Why:** `cybershack.js` (4.6 KiB) blocks the page's initial render for ~540ms. None of the features it provides (visitor counter, sparkle cursor, Now Playing) are needed for above-the-fold paint — deferring it moves it off the critical path and improves LCP and FCP.
+
+**Notes:**
+
+- Add `defer` to the `<script>` tag that loads `cybershack.js` in `themes/squalr/layouts/index.html` and `_default/baseof.html`.
+- `defer` is safe as long as no other inline script in the document depends on `cybershack.js` executing synchronously. Check for any inline `<script>` that calls functions from `cybershack.js` — if found, either also defer those or fold them into the file.
+- The script should already be wrapping DOM-dependent code in a `DOMContentLoaded` listener (or equivalent). If it isn't, the defer attribute will shift when the code runs — audit and fix the listener pattern at the same time.
+- Preconnect hints for Last.fm (see separate item) compound this improvement: with the script deferred, the browser can start the Last.fm connection earlier relative to page load.
+
+---
+
+### Defer Google Tag Manager loading
+
+**Type:** improvement
+
+**Why:** GTM loads 143 KiB on every page, with 83 KiB unused on initial load. Analytics don't need to fire during the critical render path — deferring or async-loading GTM has no user-visible impact and reduces bytes consumed on first paint.
+
+**Notes:**
+
+- GTM's standard snippet already uses an async pattern for the main `gtm.js` library, but the inline snippet itself can still block if it's synchronous.
+- Check the GTM snippet in the templates — if it's a raw `<script>` block without `async` or `defer`, that's the blocker. Adding `defer` to the script tag (or restructuring to use GTM's recommended async snippet) is the fix.
+- If the inline GTM snippet is also the source of the CSP hash violation (see bug item), moving it to an external file solves both issues at once.
+- Confirm GA4 events still fire correctly after the change — test with GTM's preview mode and the GA4 DebugView.
+
+---
+
+### Serve responsive / optimized images (Glizzy Relay)
+
+**Type:** improvement
+
+**Why:** The Glizzy Relay featured image is 1920×1070 px (212 KiB) but displayed at 683×384 px, wasting ~185 KiB per page load. Lighthouse flags this as a direct LCP contributor. The same issue likely affects other project featured images.
+
+**Notes:**
+
+- **Quick fix (do first):** resize `static/img/projects/glizzyrelay.com/featured.png` to ≤1366px wide using any image tool, and convert to WebP. Halves the bytes with no template change.
+- **Better fix:** use Hugo's built-in image processing in the project card/detail templates — `resources.Get` + `.Resize "683x" webp` generates a correctly-sized WebP at build time. Hugo caches resized images in `resources/_gen/`, which is gitignored.
+- **Best fix (stretch):** generate a `srcset` with 2–3 sizes (683w, 1024w, 1366w) so mobile gets the smallest version. Hugo's `.Resize` and `.Fill` support this with a `range` loop.
+- Audit all other files under `static/img/projects/` for the same oversize pattern while you're here — fix them all in one pass.
+- Update CLAUDE.md's image section to document the max source image width convention once a standard is set.
+
+---
+
+### Fix forced reflow in cybershack.js
+
+**Type:** improvement
+
+**Why:** Lighthouse flags 182ms of unattributed forced reflow — JavaScript is querying layout properties (e.g. `offsetWidth`) after invalidating the DOM, forcing the browser to synchronously recalculate styles. This blocks the main thread and delays interactivity.
+
+**Notes:**
+
+- Open Chrome DevTools → Performance tab → record a page load → look for tall "Recalculate Style" / "Layout" blocks triggered immediately after JS execution. The call stack will point at the offending line in `cybershack.js`.
+- Classic pattern to look for: a DOM write (setting `innerHTML`, toggling a class, changing a style) followed immediately by a geometry read (`offsetWidth`, `getBoundingClientRect`, `scrollHeight`). The read forces a flush.
+- Likely suspects: the visitor counter (updates text then reads width?), the Now Playing widget (sets album art then reads container size?), or the sparkle cursor (measures cursor position relative to DOM on mousemove).
+- Fix: batch all reads before writes, or defer the write to the next `requestAnimationFrame`. A pattern like `requestAnimationFrame(() => { el.style.width = ...; })` breaks the read-write cycle.
+- "Unattributed" in Lighthouse means it may originate in a third-party script (GTM) — profile with GTM blocked to isolate whether the reflow is first- or third-party.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 User-visible changes to squalr.us, newest first. Format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the site uses [semver](https://semver.org/) — see [BACKLOG.md](./BACKLOG.md#shipping-a-backlog-item) for how each backlog item gets versioned and migrated here.
 
+## [1.3.1] — 2026-06-01
+
+### Fixed
+
+- **CSP inline-script hash updated.** Hugo 0.162's `_internal/google_analytics.html` emits a DNT-aware variant of the gtag initializer — the old hash no longer matched, silently blocking analytics. Hash replaced with the correct SHA-256 for the current output. (`staticwebapp.config.json`)
+- **Mobile viewport overflow.** Added `html { overflow-x: hidden }` alongside the existing `body` rule. Without it, some Android Chrome builds promote `html` to the scroll container and evaluate media-query widths against the document layout width rather than the device viewport — causing the 760 px breakpoint to never fire on phones. (`cybershack.css`)
+- **`aria-label` on unlabelled `<div>` elements.** The Now Playing widget wrapper (`<div class="wa">`) and the guestbook list (`<div id="gb-list">`) both carried `aria-label` with no `role`, making the label invisible to assistive technology. Added `role="region"` to both. (`index.html`)
+- **Now Playing album art — empty `src` attribute.** `<img id="np-art" src="">` issued a spurious network request to the page URL on load. Removed the empty `src`; the JS sets `img.src` when real album art is available. (`index.html`)
+- **Project cards missing heading element.** Each `<article class="pcard">` had no `<h*>` inside it, making card boundaries unlabelled for screen readers. The project title `<span>` is now an `<h3>`, which sits correctly under the section's `<h2>`. CSS reset added to suppress default heading margin. (`pcard.html`, `cybershack.css`)
+- **Heading order — h1 → h3 skip.** Five sidebar panel headings were `<h3>` with no `<h2>` between them and the page `<h1>`, creating a gap that breaks screen-reader navigation. Promoted all five to `<h2>`. The same skip existed in related-projects, project gallery, and field-notes sections across detail-page layouts — fixed those too. (`index.html`, `pcard.html`, `related-projects.html`, `projects/single.html`, `cybershack.css`)
+
+### Changed
+
+- **Desktop Tracker project metadata.** Title cased, description updated to reflect the real product (Windows tray app, Virtual Desktop time tracking, BambooHR sync), tech stack corrected to Python / JavaScript / SVG / PyInstaller / BambooHR API, status promoted to `active`. (`content/projects/desktop-tracker.md`)
+- **CLAUDE.md frontmatter docs.** `date` and `description` fields in the "Adding a Project" example now include inline comments and real-format examples matching existing projects. (`CLAUDE.md`)
+
+---
+
 ## [1.3.0] — 2026-06-01
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,7 @@ The homepage is standalone; every other page renders through `baseof.html`, whic
 5. Reference images as `/img/blog/my-post-title/image.png`
 
 Frontmatter format:
+
 ```yaml
 ---
 title: "Post Title Here"
@@ -61,9 +62,12 @@ tags:
 Projects live in `content/projects/*.md` and render via `themes/squalr/layouts/projects/`.
 
 Supported frontmatter:
+
 ```yaml
 ---
 title: "Project Name"
+date: 2026-06-01T00:00:00+00:00   # ISO 8601; used for sorting, not displayed
+description: "One-sentence plain-English summary shown on the project card."
 status: active          # active | wip | paused | archived (colored status pill)
 weight: 10              # sort order (lower = first)
 tech: [TypeScript, Go]  # shown as tags
@@ -109,7 +113,7 @@ Both `BACKLOG.md` and `CHANGELOG.md` are rendered on the site (`/backlog/`, `/ch
 
 ## Known Issues / Tech Debt
 
-The 2021-era debt is resolved (GA4 live, Hugo pinned, GitHub Actions current, owned theme, NFT embeds stripped). Remaining candidates live in **[BACKLOG.md](./BACKLOG.md)** — notably: no mobile pass yet, no accessibility pass yet, fonts still load from Google Fonts, and OpenSea is still in the CSP allowlist. `docs/TECH-STACK-AUDIT.md` is a historical snapshot of the *starting* state, now largely superseded.
+The 2021-era debt is resolved (GA4 live, Hugo pinned, GitHub Actions current, owned theme, NFT embeds stripped). Remaining candidates live in **[BACKLOG.md](./BACKLOG.md)** — notably: no mobile pass yet, no accessibility pass yet, fonts still load from Google Fonts, and OpenSea is still in the CSP allowlist. `docs/TECH-STACK-AUDIT.md` is a historical snapshot of the _starting_ state, now largely superseded.
 
 ---
 

--- a/content/blog/still-here-new-chapter.md
+++ b/content/blog/still-here-new-chapter.md
@@ -1,7 +1,7 @@
 ---
 title: "Still Here. New Chapter."
 slug: still-here-new-chapter
-date: 2026-06-02T00:00:00+00:00
+date: 2026-06-04T00:00:00+00:00
 tags:
   - process
 ---

--- a/content/projects/desktop-tracker.md
+++ b/content/projects/desktop-tracker.md
@@ -1,8 +1,9 @@
 ---
-title: "desktop-tracker"
-date: 2026-01-01T00:00:00+00:00
-description: "A local-first time tracker that watches what I'm actually doing. Currently 90% README, 10% code. TBD."
-status: wip
+title: "Desktop Tracker"
+date: 2026-06-01T00:00:00+00:00
+description: "Windows tray app that silently tracks time per Virtual Desktop and syncs daily totals to BambooHR."
+status: active
+tech: [Python, JavaScript, SVG, PyInstaller, BambooHR API]
 repo: https://github.com/squalrus/desktop-tracker
 # Featured image — shown on the project card and at the top of this page:
 # image: /img/projects/desktop-tracker/featured.png
@@ -10,9 +11,6 @@ repo: https://github.com/squalrus/desktop-tracker
 # gallery:
 #   - src: /img/projects/desktop-tracker/screenshot.png
 #     caption: "Screenshot"
-tech:
-  - Rust
-  - Tauri
 featured: true
 weight: 40
 terminal:

--- a/static/staticwebapp.config.json
+++ b/static/staticwebapp.config.json
@@ -14,7 +14,7 @@
     },
     "globalHeaders": {
         "cache-control": "must-revalidate, max-age=604800",
-        "content-security-policy": "default-src 'self' https://squalr.us; script-src 'self' https://www.googletagmanager.com 'sha256-oxuwTr/p2fGvScGQHZP8LD7bstjXkF6e0epKyE0nZvk=' https://platform.twitter.com https://gist.github.com; style-src 'self' https://squalr.us/ https://github.githubassets.com 'unsafe-inline'; font-src 'self'; frame-src https://platform.twitter.com; connect-src https://www.google-analytics.com https://www.googletagmanager.com https://ws.audioscrobbler.com; img-src 'self' data: https://www.google-analytics.com https://lastfm.freetls.fastly.net",
+        "content-security-policy": "default-src 'self' https://squalr.us; script-src 'self' https://www.googletagmanager.com 'sha256-6ZZAev31WN2I95U/Rg8o2VlXSSo1utI7/vTo+yD9Lrg=' https://platform.twitter.com https://gist.github.com; style-src 'self' https://squalr.us/ https://github.githubassets.com 'unsafe-inline'; font-src 'self'; frame-src https://platform.twitter.com; connect-src https://www.google-analytics.com https://www.googletagmanager.com https://ws.audioscrobbler.com; img-src 'self' data: https://www.google-analytics.com https://lastfm.freetls.fastly.net",
         "x-frame-options": "DENY"
     },
     "mimeTypes": {}

--- a/themes/squalr/assets/css/cybershack.css
+++ b/themes/squalr/assets/css/cybershack.css
@@ -61,6 +61,7 @@
 }
 
 *{box-sizing:border-box}
+html{overflow-x:hidden}
 body{
   margin:0;
   font-family:var(--comic);
@@ -196,7 +197,7 @@ a:hover{ color:#fff; background:var(--hot); }
 /* ---------- sidebar ---------- */
 .side > div{ margin-bottom:14px }
 .panel{ padding:10px;background:var(--paper);border:3px ridge var(--neon-2); }
-.panel h3{ margin:0 0 8px;font-family:var(--pix);font-size:10px;color:var(--hot);
+.panel h2{ margin:0 0 8px;font-family:var(--pix);font-size:10px;color:var(--hot);
   letter-spacing:.5px;text-transform:uppercase;text-align:center;
   border-bottom:1px dashed var(--neon-2);padding-bottom:7px }
 
@@ -346,7 +347,7 @@ hr.candy{ height:6px;border:0;margin:14px 0;
 .pcard{ background:var(--paper-2);border:3px ridge var(--neon);padding:0;overflow:hidden;display:flex;flex-direction:column }
 .pcard .pchrome{ display:flex;align-items:center;justify-content:space-between;gap:6px;
   background:linear-gradient(90deg,#5b1aa6,#9b2fb0);padding:5px 8px;border-bottom:2px solid var(--zap) }
-.pcard .pname{ font-family:var(--pix);font-size:11px;color:#fff }
+.pcard .pname{ font-family:var(--pix);font-size:11px;color:#fff;margin:0 }
 .pcard .pstat{ font-family:var(--term);font-size:14px;padding:1px 7px;border:1px solid #000 }
 .pcard .pstat.on{ color:#000;background:#39ff14 }
 .pcard .pstat.wip{ color:#000;background:var(--fire) }
@@ -504,7 +505,7 @@ a.tag:hover, .tags-list-item-title:hover{ background:var(--zap);color:#000 }
 
 /* related sections (posts on a project, projects on a post) */
 .related-section, .related-projects{ margin-top:20px;border-top:2px dashed var(--hot);padding-top:12px }
-.related-section h3, .related-projects h3{ font-family:var(--comic);font-weight:700;font-size:18px;color:var(--hot);margin:0 0 10px }
+.related-section h2, .related-projects h2{ font-family:var(--comic);font-weight:700;font-size:18px;color:var(--hot);margin:0 0 10px }
 .related-projects .projgrid{ margin-top:6px }
 
 /* changelog version headings -> sticker */

--- a/themes/squalr/layouts/index.html
+++ b/themes/squalr/layouts/index.html
@@ -58,14 +58,14 @@
 
       <!-- visitor counter -->
       <div class="panel counter-wrap">
-        <h3>★ Visitors ★</h3>
+        <h2>★ Visitors ★</h2>
         <div class="odo" id="odo" role="img" aria-label="Visitor count"></div>
         <div class="lbl" aria-hidden="true">U R VISITOR!</div>
         <div class="since">online since Apr 20, 2021</div>
       </div>
 
       <!-- now playing (WinAmp) -->
-      <div class="wa" aria-label="Now playing">
+      <div class="wa" role="region" aria-label="Now playing">
         <div class="wa-title">
           <span class="wa-name" aria-hidden="true">♫ WINAMP</span>
           <div class="wa-wbtns" aria-hidden="true">
@@ -99,12 +99,12 @@
             <div class="wa-vol"><div class="wa-vol-knob"></div></div>
           </div>
         </div>
-        <img id="np-art" src="" alt="" hidden>
+        <img id="np-art" alt="" hidden>
       </div>
 
       <!-- social -->
       <div class="panel">
-        <h3>:: Connect ::</h3>
+        <h2>:: Connect ::</h2>
         <div class="social-icons">
           {{- range .Site.Params.social }}
           <a href="{{ .url }}" class="social-icon" aria-label="{{ .icon | title }}" rel="noopener noreferrer" target="_blank">
@@ -116,7 +116,7 @@
 
       <!-- status -->
       <div class="panel">
-        <h3>:: Status ::</h3>
+        <h2>:: Status ::</h2>
         <ul class="statlist">
           <li><span>currently</span> <b class="on">shipping ▸</b></li>
           <li><span>at</span> <b><a href="https://duradigital.com">Dura Digital</a></b></li>
@@ -127,7 +127,7 @@
 
       <!-- web badges -->
       <div class="panel">
-        <h3>« proudly served »</h3>
+        <h2>« proudly served »</h2>
         <div class="badges" aria-hidden="true">
           {{- range hugo.Data.badges }}{{ if .enabled }}
           <a href="{{ .url | default "#" }}" class="badge88 {{ .class }}" tabindex="-1">{{ .top }}<br><b>{{ .bottom }}</b></a>
@@ -137,7 +137,7 @@
 
       <!-- webring -->
       <div class="panel webring" aria-hidden="true">
-        <h3>The Static-Site Ring</h3>
+        <h2>The Static-Site Ring</h2>
         this site is node #14 in a<br>ring of Hugo webmasters
         <div class="nav">
           <a href="#" tabindex="-1">◀ PREV</a>
@@ -206,7 +206,7 @@
             <textarea id="gb-msg" maxlength="240" placeholder="say something rad..."></textarea>
             <div><button class="gb-send" type="submit">»» STAMP IT ««</button></div>
           </form>
-          <div class="gb-list" id="gb-list" aria-live="polite" aria-label="Guestbook entries"></div>
+          <div class="gb-list" id="gb-list" role="region" aria-live="polite" aria-label="Guestbook entries"></div>
           <div class="gb-count" id="gb-count" aria-live="polite"></div>
           <div style="font-family:var(--comic);font-size:11px;color:var(--ink-2);text-align:center;margin-top:8px">(entries save to your own browser — it's a 90s tribute, not a server 😉)</div>
         </div>

--- a/themes/squalr/layouts/partials/pcard.html
+++ b/themes/squalr/layouts/partials/pcard.html
@@ -4,7 +4,7 @@
 {{- $slug := .File.ContentBaseName -}}
 {{- $notes := where site.RegularPages "Params.projects" "intersect" (slice $slug) -}}
 <article class="pcard">
-  <div class="pchrome"><span class="pname"><a href="{{ .Permalink }}">{{ .Title }}</a></span><span class="pstat {{ $statusClass }}">{{ .Params.status | upper }}</span></div>
+  <div class="pchrome"><h3 class="pname"><a href="{{ .Permalink }}">{{ .Title }}</a></h3><span class="pstat {{ $statusClass }}">{{ .Params.status | upper }}</span></div>
   <div class="shot">
     {{- with .Params.image }}
     <span class="shothint">⌖ screenshot.gif</span>

--- a/themes/squalr/layouts/partials/related-projects.html
+++ b/themes/squalr/layouts/partials/related-projects.html
@@ -1,6 +1,6 @@
 {{- with .Params.projects }}
 <div class="related-projects">
-  <h3>◇ Related projects</h3>
+  <h2>◇ Related projects</h2>
   <div class="projgrid">
     {{- range . }}
     {{- with site.GetPage (printf "/projects/%s" .) }}{{ partial "pcard.html" . }}{{ end }}

--- a/themes/squalr/layouts/projects/single.html
+++ b/themes/squalr/layouts/projects/single.html
@@ -25,7 +25,7 @@
     </div>
     {{- with .Params.gallery }}
     <section class="project-gallery">
-      <h3 class="project-gallery-label">📸 screenshots.zip</h3>
+      <h2 class="project-gallery-label">📸 screenshots.zip</h2>
       <div class="project-gallery-grid">
         {{- range . }}
         <figure class="project-gallery-item">
@@ -40,7 +40,7 @@
     {{- $related := where site.RegularPages "Params.projects" "intersect" (slice $slug) }}
     {{- with $related }}
     <div class="related-section">
-      <h3>◇ Field notes about this project</h3>
+      <h2>◇ Field notes about this project</h2>
       <ul class="posts">
         {{- range . }}
         {{ partial "post-li.html" (dict "page" .) }}


### PR DESCRIPTION
- CSP script-src hash updated for Hugo 0.162 GA template output
- html { overflow-x: hidden } added to fix Android mobile breakpoint
- role="region" added to .wa and #gb-list (aria-label on generic div)
- Empty src removed from Now Playing album art img
- pcard title promoted from span to h3; heading margin reset in CSS
- Sidebar h3s promoted to h2 (h1→h3 skip); related-projects, gallery, and field-notes headings fixed across detail layouts and CSS selectors
- desktop-tracker metadata updated (stack, description, status active)
- CLAUDE.md frontmatter examples updated (date/description fields)