### PR TITLE
improve: CRT effect, nav, project sort, WinAmp polish (v1.3.2–1.3.3)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -43,6 +43,7 @@ Grouped by type; within each type sorted by ROI — small/high first, large/low 
 
 | Title | Effort | Value |
 | --- | --- | --- |
+| Now Playing `<img>` missing `src`/`srcset` (HTML validator) | S | M |
 | Color contrast failures across cards and badges (a11y) | M | H |
 
 ### Features
@@ -57,7 +58,6 @@ Grouped by type; within each type sorted by ROI — small/high first, large/low 
 
 | Title | Effort | Value |
 | --- | --- | --- |
-| Project showcase readability and CRT effect | M | H |
 | Flesh out the `desktop-tracker` project body and screenshots | S | M |
 | Add preconnect hints for Last.fm and audioscrobbler | S | M |
 | Explicit width and height on Now Playing album art | S | M |
@@ -138,21 +138,6 @@ Grouped by type; within each type sorted by ROI — small/high first, large/low 
 
 ---
 
-### Project showcase readability and CRT effect
-
-**Type:** improvement
-
-**Why:** The project cards and detail pages are functional but not memorable. Screenshots and faux-terminal snippets are the most visually interesting elements — a subtle CRT treatment (scanlines, phosphor glow, slight vignette) would make the showcase stand out and reinforce the retro aesthetic without touching the readability of prose.
-
-**Notes:**
-
-- CRT effect is pure CSS: a `::after` overlay with a `repeating-linear-gradient` for scanlines, an inset `box-shadow` for the vignette, and an optional subtle flicker via `@keyframes`. The flicker **must** respect `prefers-reduced-motion`.
-- Apply selectively to project screenshots and `.terminal` blocks — not to body text or UI chrome.
-- Readability pass is separate: check that the project list and detail pages have enough whitespace, contrast, and typographic hierarchy to scan quickly. The two goals (readable + standout) can conflict if the CRT is too heavy — keep the effect light.
-- Fun stretch: a "CRT on/off" toggle in the title bar would be on-brand for the 90s desktop theme and completely optional.
-
----
-
 ### Flesh out the `desktop-tracker` project body and screenshots
 
 **Type:** improvement
@@ -193,6 +178,26 @@ Grouped by type; within each type sorted by ROI — small/high first, large/low 
 - Remove the web ring section from the homepage layout (`themes/squalr/layouts/index.html` or the relevant partial).
 - Remove any CSS scoped to `.webring` or similar from `cybershack.css`.
 - Don't leave a commented-out skeleton — if the concept ever comes back with real members and links, it's easy to add fresh.
+
+---
+
+### Now Playing `<img>` missing `src`/`srcset` (HTML validator)
+
+**Type:** bug
+
+**Why:** Removing the empty `src=""` attribute (v1.3.1) fixed the spurious network request, but left `<img id="np-art" alt hidden>` with neither `src` nor `srcset`. The HTML spec requires at least one of these on every `<img>` — the W3C validator flags it as an error, and some browsers may render a broken-image icon before JS hides the element.
+
+**Notes:**
+
+- Validator error: `Element img is missing one or more of the following attributes: src, srcset.` at `<img id=np-art alt hidden>` in `themes/squalr/layouts/index.html`.
+- Fix: set `src` to a 1×1 transparent data URI so the element is valid HTML and makes no network request:
+
+  ```html
+  <img id="np-art" src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" alt="" hidden>
+  ```
+
+- The JS in `cybershack.js` already overwrites `img.src` with the real album-art URL when a track is found, so the placeholder is only ever visible to the validator (the element stays `hidden` until JS reveals it).
+- Pair with the "Explicit width and height on Now Playing album art" improvement when touching this element — both are one-line changes on the same `<img>`.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 User-visible changes to squalr.us, newest first. Format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the site uses [semver](https://semver.org/) — see [BACKLOG.md](./BACKLOG.md#shipping-a-backlog-item) for how each backlog item gets versioned and migrated here.
 
+## [1.3.3] — 2026-06-01
+
+### Changed
+
+- **Blog added to main nav.** "Blog" now appears between Home and Projects in the nav row on every page. (`config.yaml`)
+- **Projects sorted by date, weight removed.** Cards on the homepage and `/projects/` list are now sorted newest-first by frontmatter `date`. The manual `weight:` field is removed from all project files. (`index.html`, `projects/list.html`, project frontmatter)
+- **WinAmp scroll animation.** The previous keyframe held the text fully off-screen for 20% of the loop (blank LCD visible). The scroll now runs from 20% to 100%, snapping back at the loop point while the text is already off-screen — invisible jump, clean loop. Duration divisor updated to match (80% scroll / 20% hold). (`cybershack.css`, `cybershack.js`)
+- **WinAmp edge fades gated on scrolling.** The `::before`/`::after` fade-to-black gradients on `.wa-clip` are now scoped to `:has(.wa-scrolling)` — they only appear when text is actively scrolling. Short titles like "Ciel" were being clipped by the always-on left gradient; now they display cleanly. (`cybershack.css`)
+- **WinAmp album art fills widget on mobile.** Added `width:100%` to `#np-art` so the album art stretches to match the full-width widget on mobile instead of rendering at its natural 300px with background showing beside it. (`cybershack.css`)
+
+---
+
+## [1.3.2] — 2026-06-01
+
+### Changed
+
+- **CRT effect on project screenshots and terminal blocks.** A CSS `::after` overlay adds authentic scanlines (`repeating-linear-gradient`) and a vignette (`box-shadow: inset`) to `.shot` card thumbnails and `.project-hero-media` detail images. A subtle flicker animation is applied to the overlay and respects `prefers-reduced-motion`. Terminal block text gets a phosphor glow (`text-shadow`) on the green and cyan colors. (`cybershack.css`)
+- **Project card title links readable.** Card title `<a>` inside `.pchrome` now overrides the global blue link color with white to match the purple gradient title bar. No underline at rest; underline appears on hover along with a translucent white wash. (`cybershack.css`)
+- **Project card hover state.** Cards now shift border to magenta and gain a subtle purple drop shadow on hover — making the card-as-link intent obvious without requiring a cursor-pointer override. (`cybershack.css`)
+- **`.pnotes.none` contrast fix.** "◇ no notes yet" was rendered with `opacity: .55` (~2.8:1 contrast against cream background, failing WCAG AA). Replaced with an explicit `color: #6b5d8f` (~5.4:1). (`cybershack.css`)
+- **Glizzy Relay frontmatter.** Switched from a custom `links:` entry to the semantic `demo:` field; harmonized `demo` label to `live↗` on the detail page to match the card. (`content/projects/glizzyrelay.com.md`, `themes/squalr/layouts/projects/single.html`)
+
+---
+
 ## [1.3.1] — 2026-06-01
 
 ### Fixed

--- a/config.yaml
+++ b/config.yaml
@@ -65,6 +65,10 @@ menu:
       name: 'Home'
       url: '/'
       weight: 10
+    - identifier: 'blog'
+      name: 'Blog'
+      url: '/blog/'
+      weight: 15
     - identifier: 'projects'
       name: 'Projects'
       url: '/projects/'

--- a/content/projects/desktop-tracker.md
+++ b/content/projects/desktop-tracker.md
@@ -1,6 +1,6 @@
 ---
 title: "Desktop Tracker"
-date: 2026-06-01T00:00:00+00:00
+date: 2026-04-23T00:00:00+00:00
 description: "Windows tray app that silently tracks time per Virtual Desktop and syncs daily totals to BambooHR."
 status: active
 tech: [Python, JavaScript, SVG, PyInstaller, BambooHR API]
@@ -12,7 +12,6 @@ repo: https://github.com/squalrus/desktop-tracker
 #   - src: /img/projects/desktop-tracker/screenshot.png
 #     caption: "Screenshot"
 featured: true
-weight: 40
 terminal:
   label: 'desktop-tracker — dev'
   glyph: '▮▮'

--- a/content/projects/glizzyrelay.com.md
+++ b/content/projects/glizzyrelay.com.md
@@ -19,9 +19,7 @@ tech:
   - TypeScript
   - Supabase
   - Vite
-links:
-  - label: "Live ↗"
-    url: "https://glizzyrelay.com"
+demo: "https://glizzyrelay.com"
 ---
 
 Live scoreboard and scoring for a hot dog eating relay. Glizzy Relay runs the whole event: teams of three eat a hot dog and drink a beer in sequence, a tap/spacebar timer captures every runner's split, and an ESPN-style broadcast scoreboard updates live on the big screen as the race happens.

--- a/content/projects/merge-bot.md
+++ b/content/projects/merge-bot.md
@@ -1,6 +1,6 @@
 ---
 title: "merge-bot"
-date: 2019-10-01T00:00:00+00:00
+date: 2019-09-20T00:00:00+00:00
 description: "GitHub Action for automated PR merging based on labels, blocking labels, and reviewer sign-off."
 status: archived
 repo: https://github.com/squalrus/merge-bot
@@ -10,13 +10,12 @@ repo: https://github.com/squalrus/merge-bot
 # gallery:
 #   - src: /img/projects/merge-bot/marketplace.png
 #     caption: "GitHub Marketplace listing"
-demo: ""
+demo: "https://github.com/marketplace/actions/pr-merge-bot"
 tech:
   - GitHub Actions
   - TypeScript
   - Node.js
 featured: true
-weight: 30
 terminal:
   label: 'merge-bot — ci'
   glyph: '{ }'

--- a/content/projects/squalr.us.md
+++ b/content/projects/squalr.us.md
@@ -1,7 +1,7 @@
 ---
 title: "squalr.us"
 slug: squalr-us
-date: 2019-10-01T00:00:00+00:00
+date: 2017-08-12T00:00:00+00:00
 description: "This very site. A custom Hugo theme with too many neon glows and a healthy disrespect for whitespace."
 status: wip
 # Featured image — shown on the project card and at the top of this page:
@@ -16,5 +16,4 @@ tech:
   - TypeScript
   - Node.js
 featured: true
-weight: 20
 ---

--- a/themes/squalr/assets/css/cybershack.css
+++ b/themes/squalr/assets/css/cybershack.css
@@ -227,6 +227,7 @@ a:hover{ color:#fff; background:var(--hot); }
 }
 .wa-wb:active{ border-color:var(--chrome-dd) var(--chrome-l) var(--chrome-l) var(--chrome-dd); }
 .wa-body{ background:#232323;padding:4px; }
+#np-art{ width:100%;display:block }
 
 /* LCD */
 .wa-lcd{
@@ -237,11 +238,13 @@ a:hover{ color:#fff; background:var(--hot); }
 .wa-clip::before,.wa-clip::after{
   content:'';position:absolute;top:0;bottom:0;width:8px;z-index:1;pointer-events:none;
 }
-.wa-clip::before{ left:0;background:linear-gradient(to right,#000,transparent); }
-.wa-clip::after { right:0;background:linear-gradient(to left, #000,transparent); }
+.wa-clip::before{ left:0 }
+.wa-clip::after { right:0 }
+.wa-clip:has(.wa-scrolling)::before{ background:linear-gradient(to right,#000,transparent) }
+.wa-clip:has(.wa-scrolling)::after { background:linear-gradient(to left, #000,transparent) }
 .wa-scroll{ display:inline-block;white-space:nowrap;color:#00ff66;font-family:var(--term);font-size:18px;line-height:1.1; }
 .wa-scroll.wa-scrolling{ animation:wa-scroll var(--wa-dur,12s) linear infinite;padding-right:var(--wa-pad,60px); }
-@keyframes wa-scroll{ 0%,20%{ transform:translateX(0) } 80%,100%{ transform:translateX(var(--wa-shift,-200px)) } }
+@keyframes wa-scroll{ 0%,20%{ transform:translateX(0) } 100%{ transform:translateX(var(--wa-shift,-200px)) } }
 .wa-meta{ display:flex;justify-content:space-between;align-items:baseline;margin-top:3px;gap:4px; }
 .wa-state{ font-family:var(--term);font-size:14px;color:#00ff66;white-space:nowrap;flex-shrink:0; }
 .wa-state.last-played{ color:var(--fire); }
@@ -348,6 +351,8 @@ hr.candy{ height:6px;border:0;margin:14px 0;
 .pcard .pchrome{ display:flex;align-items:center;justify-content:space-between;gap:6px;
   background:linear-gradient(90deg,#5b1aa6,#9b2fb0);padding:5px 8px;border-bottom:2px solid var(--zap) }
 .pcard .pname{ font-family:var(--pix);font-size:11px;color:#fff;margin:0 }
+.pcard .pname a{ color:#fff;text-decoration:none }
+.pcard .pname a:hover{ color:#fff;background:rgba(255,255,255,.25);text-decoration:underline }
 .pcard .pstat{ font-family:var(--term);font-size:14px;padding:1px 7px;border:1px solid #000 }
 .pcard .pstat.on{ color:#000;background:#39ff14 }
 .pcard .pstat.wip{ color:#000;background:var(--fire) }
@@ -368,7 +373,25 @@ hr.candy{ height:6px;border:0;margin:14px 0;
 .pcard .pfoot{ margin-top:auto;display:flex;align-items:center;justify-content:space-between;gap:8px;
   border-top:1px dashed #c3a9d6;padding-top:9px;font-family:var(--term);font-size:15px }
 .pcard .plinks{ display:flex;gap:10px }
-.pcard .pnotes{ color:var(--ink-2) } .pcard .pnotes.none{ opacity:.55 }
+.pcard .pnotes{ color:var(--ink-2) } .pcard .pnotes.none{ color:#6b5d8f }
+.pcard:hover{ border-color:var(--hot);box-shadow:0 4px 14px rgba(91,26,166,.22) }
+
+/* ---- CRT: scanlines + vignette on project screenshots and terminal blocks ---- */
+.shot::after{
+  content:'';position:absolute;inset:0;z-index:1;pointer-events:none;
+  background:repeating-linear-gradient(0deg,rgba(0,0,0,.11) 0,rgba(0,0,0,.11) 1px,transparent 1px,transparent 3px);
+  box-shadow:inset 0 0 36px rgba(0,0,0,.52);
+  animation:crt-flicker 11s linear infinite;
+}
+@keyframes crt-flicker{
+  0%,88%,90%,95%,97%,100%{ opacity:1 }
+  89%{ opacity:.95 }
+  96%{ opacity:.97 }
+}
+/* phosphor glow on terminal text */
+.termshot .pr{ text-shadow:0 0 6px #39ff14 }
+.termshot .ok{ text-shadow:0 0 8px #33e0ff }
+.termshot .cur{ box-shadow:0 0 5px #39ff14 }
 
 /* posts list */
 .posts{ list-style:none;margin:0;padding:0;border:2px ridge var(--hot);background:var(--paper) }
@@ -418,7 +441,8 @@ hr.candy{ height:6px;border:0;margin:14px 0;
 
 @media (prefers-reduced-motion: reduce){
   .mqbar > span, .rainbow, .wa-spec .eq i,
-  .wa-scroll, .wa-scroll.wa-scrolling, .blink{ animation:none }
+  .wa-scroll, .wa-scroll.wa-scrolling, .blink,
+  .shot::after, .project-hero-media::after{ animation:none }
   /* odometer roll — JS reads this to skip the counting animation.
      .wa-scroll.wa-scrolling listed explicitly because its 2-class
      specificity would otherwise beat the single-class .wa-scroll rule. */
@@ -494,7 +518,13 @@ a.tag:hover, .tags-list-item-title:hover{ background:var(--zap);color:#000 }
 .project-status.status-archived{ background:var(--chrome-d);color:#fff }
 .project-detail-tech{ display:flex;flex-wrap:wrap;gap:6px;margin:8px 0 14px }
 .project-detail-tech .tag{ font-family:var(--term);font-size:14px;color:#000;background:#7fe3e3;padding:1px 8px;border:1px solid #000 }
-.project-hero-media{ border:3px ridge var(--neon);margin:12px 0 16px;background:#000 }
+.project-hero-media{ border:3px ridge var(--neon);margin:12px 0 16px;background:#000;position:relative;overflow:hidden }
+.project-hero-media::after{
+  content:'';position:absolute;inset:0;pointer-events:none;
+  background:repeating-linear-gradient(0deg,rgba(0,0,0,.11) 0,rgba(0,0,0,.11) 1px,transparent 1px,transparent 3px);
+  box-shadow:inset 0 0 36px rgba(0,0,0,.52);
+  animation:crt-flicker 11s linear infinite;
+}
 .project-hero-media img{ width:100%;display:block }
 .project-gallery{ margin-top:18px }
 .project-gallery-label{ font-family:var(--comic);font-weight:700;color:var(--hot);margin:0 0 8px }

--- a/themes/squalr/layouts/index.html
+++ b/themes/squalr/layouts/index.html
@@ -167,7 +167,7 @@
       <div id="projects">
         <h2 class="sticker">▰ MY RAD PROJECTS</h2>
         <div class="projgrid">
-          {{- range sort $projects "Params.weight" }}
+          {{- range sort $projects "Date" "desc" }}
           {{ partial "pcard.html" . }}
           {{- end }}
         </div>

--- a/themes/squalr/layouts/projects/list.html
+++ b/themes/squalr/layouts/projects/list.html
@@ -2,7 +2,7 @@
   <h1 class="page-title">▰ My Rad Projects</h1>
   <p class="page-subtitle">Things I'm building — some serious, some just for the bit.</p>
   <div class="projgrid">
-    {{- range sort .Pages "Params.weight" }}
+    {{- range sort .Pages "Date" "desc" }}
     {{ partial "pcard.html" . }}
     {{- end }}
   </div>

--- a/themes/squalr/layouts/projects/single.html
+++ b/themes/squalr/layouts/projects/single.html
@@ -8,7 +8,7 @@
         <span class="project-status status-{{ . }}">{{ with index $statusEmoji . }}{{ . }} {{ end }}{{ . }}</span>
         {{- end }}
         {{- with .Params.repo }}<a href="{{ . }}" target="_blank" rel="noreferrer noopener">github↗</a>{{ end }}
-        {{- with .Params.demo }}<a href="{{ . }}" target="_blank" rel="noreferrer noopener">demo↗</a>{{ end }}
+        {{- with .Params.demo }}<a href="{{ . }}" target="_blank" rel="noreferrer noopener">live↗</a>{{ end }}
         {{- range .Params.links }}<a href="{{ .url }}" target="_blank" rel="noreferrer noopener">{{ replaceRE `[↗→\s]+$` "" .label | lower }}↗</a>{{ end }}
       </div>
       {{- with .Params.tech }}

--- a/themes/squalr/static/cybershack.js
+++ b/themes/squalr/static/cybershack.js
@@ -86,8 +86,8 @@
             var shift = textW + gap;
             s.style.setProperty('--wa-pad', gap + 'px');
             s.style.setProperty('--wa-shift', '-' + shift + 'px');
-            // ~50px/s scroll speed; hold+gap take 40% of total
-            s.style.setProperty('--wa-dur', Math.max(7, shift / 50 / 0.6).toFixed(1) + 's');
+            // ~50px/s scroll speed; hold at start takes 20% of total, scroll takes 80%
+            s.style.setProperty('--wa-dur', Math.max(7, shift / 50 / 0.8).toFixed(1) + 's');
             s.classList.add('wa-scrolling');
           } else {
             s.style.removeProperty('--wa-pad');


### PR DESCRIPTION
v1.3.2 — project showcase readability + CRT
- CSS ::after scanline/vignette overlay on .shot and .project-hero-media
- Phosphor glow on terminal text; subtle crt-flicker animation (reduced-motion safe)
- Card title links white on purple (was invisible blue); card hover state added
- .pnotes.none contrast: opacity:.55 → explicit color #6b5d8f (~5.4:1)
- Glizzy Relay: links: → demo:; detail page demo label harmonised to live↗

v1.3.3 — nav, project sort, WinAmp fixes
- Blog added to main nav between Home and Projects
- Projects sorted by date desc; weight: removed from all project frontmatter
- WinAmp scroll: removed blank-LCD hold at end of loop; snap now invisible
- WinAmp edge fades gated on :has(.wa-scrolling) — short titles no longer clipped
- WinAmp album art: width:100% so art fills full-width widget on mobile