### PR TITLE
fix: WinAmp loved-heart always visible (v1.6.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 User-visible changes to squalr.us, newest first. Format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the site uses [semver](https://semver.org/) — see [BACKLOG.md](./BACKLOG.md#shipping-a-backlog-item) for how each backlog item gets versioned and migrated here.
 
+## [1.6.2] — 2026-06-02
+
+### Fixed
+
+- **WinAmp loved-heart always visible.** The ❤ indicator was previously toggled via `hidden` attribute in JS (`loved.hidden = track.loved !== '1'`), so it only appeared when the currently-loaded track had been loved — invisible on cold page load until the Next.js polling resolved. Removed the `hidden` attribute from the HTML element and the `loved.hidden` assignment from JS; the heart now shows persistently. (`index.html`, `cybershack.js`)
+
 ## [1.6.1] — 2026-06-02
 
 ### Changed

--- a/themes/squalr/layouts/index.html
+++ b/themes/squalr/layouts/index.html
@@ -82,7 +82,7 @@
             </div>
             <div class="wa-meta">
               <span class="wa-state" id="np-label">▶ playing</span>
-              <span class="wa-loved" id="np-loved" aria-label="loved track" hidden>❤</span>
+              <span class="wa-loved" id="np-loved" aria-label="loved track">❤</span>
               <span class="wa-who" id="np-artist">Loading...</span>
             </div>
           </div>

--- a/themes/squalr/static/cybershack.js
+++ b/themes/squalr/static/cybershack.js
@@ -48,7 +48,6 @@
         art   = document.getElementById('np-art'),
         eq    = document.getElementById('np-eq'),
         lbl   = document.getElementById('np-label'),
-        loved = document.getElementById('np-loved'),
         mq    = document.getElementById('mq-track');
     var hasWidget = !!(s && a);
     if (!hasWidget && !mq) return;
@@ -75,7 +74,6 @@
           lbl.textContent = isNow ? '▶ playing' : '■ last played';
           lbl.className = 'wa-state' + (isNow ? '' : ' last-played');
         }
-        if (loved) loved.hidden = track.loved !== '1';
         // Adaptive marquee: only scroll when text actually overflows the clip container
         var wrap = s.parentElement;
         if (wrap) {


### PR DESCRIPTION
Remove hidden attribute and loved.hidden JS toggle so the heart ❤ shows persistently instead of only appearing after the Last.fm polling resolves on a loaded track.