### PR TITLE
improvement: links in post bodies and external template links open in…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 User-visible changes to squalr.us, newest first. Format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the site uses [semver](https://semver.org/) — see [BACKLOG.md](./BACKLOG.md#shipping-a-backlog-item) for how each backlog item gets versioned and migrated here.
 
+## [1.6.3] — 2026-06-03
+
+### Changed
+
+- **External links and in-post body links open in a new tab.** A Hugo Markdown render hook (`layouts/_default/_markup/render-link.html`) now intercepts every link in post and project body copy — all open in a new tab, with `rel="noopener noreferrer"` added for external URLs. Template links that were missing `target="_blank"` are also fixed: project card `demo`, `repo`, and custom `links` in `pcard.html`; the Hugo credit in `baseof.html`; and the three Dura Digital links and the Hugo credit in `index.html`. Suggested by [Fiorella Franzini](https://linkedin.com/in/fiorella-franzini).
+
 ## [1.6.2] — 2026-06-02
 
 ### Fixed

--- a/themes/squalr/layouts/_default/_markup/render-link.html
+++ b/themes/squalr/layouts/_default/_markup/render-link.html
@@ -1,0 +1,7 @@
+{{- $external := strings.HasPrefix .Destination "http" -}}
+{{- $rel := cond $external "noopener noreferrer" "" -}}
+<a href="{{ .Destination | safeURL }}"
+  {{- with .Title }} title="{{ . }}"{{ end }}
+  target="_blank"
+  {{- if $rel }} rel="{{ $rel }}"{{ end -}}
+>{{ .Text | safeHTML }}</a>

--- a/themes/squalr/layouts/_default/baseof.html
+++ b/themes/squalr/layouts/_default/baseof.html
@@ -70,7 +70,7 @@
       <a href="{{ .url | default "#" }}" class="badge88 {{ .class }}" tabindex="-1">{{ .top }}<br><b>{{ .bottom }}</b></a>
       {{- end }}{{ end }}
     </div>
-    <div class="smol">Built with <a href="https://gohugo.io">Hugo</a> and GeoCities</div>
+    <div class="smol">Built with <a href="https://gohugo.io" target="_blank" rel="noopener noreferrer">Hugo</a> and GeoCities</div>
     <div class="viewed">☆ NO FRAMES · NO COOKIES · GEOCITIES APPROVED ☆</div>
   </div>
 

--- a/themes/squalr/layouts/index.html
+++ b/themes/squalr/layouts/index.html
@@ -37,7 +37,7 @@
   <div class="banner-top">
     <div class="eyebrow" aria-hidden="true">·:¦:· {{ .Site.Params.hero.kicker }} ·:¦:·</div>
     <h1 class="wordmark"><span class="rainbow">{{$lit}}</span><span style="color:var(--hot)" aria-hidden="true">!!!</span></h1>
-    <div class="tag">Sr Consultant @ <a href="https://duradigital.com">Dura Digital</a> · music · pixels · <span class="hi">random projects</span></div>
+    <div class="tag">Sr Consultant @ <a href="https://duradigital.com" target="_blank" rel="noopener noreferrer">Dura Digital</a> · music · pixels · <span class="hi">random projects</span></div>
     <div class="constr" aria-hidden="true">
       <span class="digger">⛏</span> <span class="txt">UNDER CONSTRUCTION SINCE 2001</span> <span class="digger">🚧</span>
     </div>
@@ -129,7 +129,7 @@
       <div class="panel">
         <h2>:: Status ::</h2>
         <ul class="statlist">
-          <li><span>at</span> <b><a href="https://duradigital.com">Dura Digital</a></b></li>
+          <li><span>at</span> <b><a href="https://duradigital.com" target="_blank" rel="noopener noreferrer">Dura Digital</a></b></li>
           <li><span>projects</span> <b>{{ len $projects }}</b></li>
           <li><span>coffee level</span> <b class="wip">critical</b></li>
         </ul>
@@ -157,7 +157,7 @@
           <span class="tb-btns" aria-hidden="true"><i>_</i><i>▢</i><i>✕</i></span>
         </div>
         <div class="body welcome">
-          <p><b class="pop">Hey! I'm Chad.</b> 🏄 Sr Consultant at <a href="https://duradigital.com">Dura Digital</a> — helping teams ship real products for real people. Off the clock I build things that make me happy and teach me something along the way. Usually both.</p>
+          <p><b class="pop">Hey! I'm Chad.</b> 🏄 Sr Consultant at <a href="https://duradigital.com" target="_blank" rel="noopener noreferrer">Dura Digital</a> — helping teams ship real products for real people. Off the clock I build things that make me happy and teach me something along the way. Usually both.</p>
           <p><b>squalr.us</b> is my corner of the internet: built with Hugo, stuck in 1997, and fueled by caffeine and music. <a href="#guestbook">Sign the guestbook</a> before you leave — don't be a lurker.</p>
         </div>
       </div>
@@ -227,7 +227,7 @@
           <a href="{{ .url | default "#" }}" class="badge88 {{ .class }}" tabindex="-1">{{ .top }}<br><b>{{ .bottom }}</b></a>
           {{- end }}{{ end }}
         </div>
-        <div class="smol">Built with <a href="https://gohugo.io">Hugo</a> and GeoCities</div>
+        <div class="smol">Built with <a href="https://gohugo.io" target="_blank" rel="noopener noreferrer">Hugo</a> and GeoCities</div>
         <div class="viewed">☆ NO FRAMES · NO COOKIES · GEOCITIES APPROVED ☆</div>
       </div>
 

--- a/themes/squalr/layouts/partials/pcard.html
+++ b/themes/squalr/layouts/partials/pcard.html
@@ -33,9 +33,9 @@
     {{- with .Params.tech }}<div class="ptags">{{ range . }}<span>{{ . }}</span>{{ end }}</div>{{ end }}
     <div class="pfoot">
       <span class="plinks">
-        {{- with .Params.demo }}<a href="{{ . }}">live↗</a>{{ end }}
-        {{- with .Params.repo }}<a href="{{ . }}">github↗</a>{{ end }}
-        {{- range .Params.links }}<a href="{{ .url }}">{{ replaceRE `[↗→\s]+$` "" .label | lower }}↗</a>{{ end }}
+        {{- with .Params.demo }}<a href="{{ . }}" target="_blank" rel="noopener noreferrer">live↗</a>{{ end }}
+        {{- with .Params.repo }}<a href="{{ . }}" target="_blank" rel="noopener noreferrer">github↗</a>{{ end }}
+        {{- range .Params.links }}<a href="{{ .url }}" target="_blank" rel="noopener noreferrer">{{ replaceRE `[↗→\s]+$` "" .label | lower }}↗</a>{{ end }}
       </span>
       {{- if $notes }}<a class="pnotes" href="{{ .Permalink }}">◇ {{ len $notes }} note{{ if gt (len $notes) 1 }}s{{ end }}</a>{{ else }}<span class="pnotes none">◇ no notes yet</span>{{ end }}
     </div>


### PR DESCRIPTION
… new tab (v1.6.3)

- Add Hugo render hook (layouts/_default/_markup/render-link.html) so all Markdown links in post/project bodies open target="_blank"; external links also get rel="noopener noreferrer"
- Fix missing target="_blank" on project card demo/repo/links in pcard.html, Hugo credit in baseof.html, and three Dura Digital + Hugo credit links in index.html