### PR TITLE
feat: functional Win95 window controls + Win2000 taskbar (v1.6.5)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -49,7 +49,6 @@ _No open bug items._
 | --- | --- | --- |
 | Scheduled rebuild so future-dated posts auto-publish | S | M |
 | CSS-only gallery lightbox | S | M |
-| Windows minimize, maximize, and close | M | H |
 | AIM-style buddy list widget backed by Steam friends API | M | H |
 | Replace fake guestbook with GitHub Discussions (Giscus) | M | M |
 
@@ -105,24 +104,6 @@ _No open cleanup items._
 - Respect `prefers-reduced-motion` for the fade.
 - Trap: `:target` lightboxes can fight the browser back button and scroll position. Test that closing returns the visitor to where they were on the page.
 - If `:target` gets fiddly, a tiny vanilla-JS lightbox (no dependency) is the fallback — but try CSS first to keep the no-build ethos.
-
----
-
-### Windows minimize, maximize, and close
-
-**Type:** feature
-
-**Why:** The Win95-style windows have decorative title bar buttons but they do nothing on click. Making them functional would be on-brand — minimize collapses a window to a taskbar entry, close hides it, maximize fills the viewport — and makes the homepage feel like an actual desktop rather than a static mockup.
-
-**Notes:**
-
-- Keep JS minimal: a small vanilla module that toggles classes. No framework.
-- **Minimize:** collapse the window to show only its title bar; add a taskbar entry at the bottom of the screen that restores it on click.
-- **Maximize:** expand the window to fill the main content area, storing original dimensions for restore. Double-click on the title bar is the classic trigger.
-- **Close:** hide the window entirely; add a way to reopen (a taskbar entry or a clickable "desktop icon").
-- Persist state in `sessionStorage` so windows stay closed/minimized across soft navigations but reset on a fresh visit.
-- JS goes in `themes/squalr/assets/js/` and is bundled through Hugo Pipes (same pattern as existing scripts).
-- Degrade gracefully with no JS — buttons just don't respond, same as today.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 User-visible changes to squalr.us, newest first. Format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the site uses [semver](https://semver.org/) — see [BACKLOG.md](./BACKLOG.md#shipping-a-backlog-item) for how each backlog item gets versioned and migrated here.
 
+## [1.6.5] — 2026-06-03
+
+### Added
+
+- **Functional Win95 window controls (minimize, maximize, close).** All `.win` title-bar buttons and the WinAmp title-bar buttons now work. Minimize collapses the window to its title bar; maximize expands it to fill the viewport (double-clicking the title bar also toggles maximize); close hides it entirely. WinAmp `_`/`□` toggle shade mode (compact title-bar-only view); `×` closes the player. State persists in `sessionStorage` and resets on a fresh visit. Degrades gracefully with no JS. All four window instances (homepage welcome, homepage guestbook, WinAmp player, inner-page content) share a single `partials/win-btns.html` partial so button markup is identical everywhere. (`win-btns.html`, `_win95.scss`, `_winamp.scss`, `cybershack.js`)
+- **Win2000-style taskbar.** When any window is minimized or closed, a fixed taskbar appears at the bottom of the screen with three zones: a **Start button** (site favicon + "Start" label, far left), a **task strip** (restore buttons for each minimized/closed window or player, center), and a **live clock** in a sunken system-tray inset (far right, updates every second). Clicking **Start** clears `sessionStorage` and restores every window and the WinAmp player to their default visible state, then dismisses the taskbar. (`_win95.scss`, `cybershack.js`)
+- **"NEW!" badge on project cards.** Projects with a `date:` within the last 45 days now display the same blinking red `NEW!` badge used on post list rows. (`pcard.html`)
+
 ## [1.6.4] — 2026-06-03
 
 ### Changed

--- a/themes/squalr/assets/css/_win95.scss
+++ b/themes/squalr/assets/css/_win95.scss
@@ -23,26 +23,6 @@
       white-space: nowrap;
     }
 
-    .tb-btns {
-      display: flex;
-      gap: 3px;
-
-      i {
-        width: 15px;
-        height: 13px;
-        display: grid;
-        place-items: center;
-        background: var(--chrome);
-        border: 1px solid;
-        border-color: var(--chrome-l) var(--chrome-dd) var(--chrome-dd) var(--chrome-l);
-        color: #000;
-        font-family: var(--comic);
-        font-weight: 700;
-        font-size: 10px;
-        font-style: normal;
-        line-height: 1;
-      }
-    }
   }
 
   .body {
@@ -52,5 +32,142 @@
     border-color: var(--chrome-l) var(--chrome-dd) var(--chrome-dd) var(--chrome-l);
     border-top: none;
     overflow-wrap: break-word;
+  }
+
+  // JS-toggled window states
+  &.win-minimized .body { display: none; }
+
+  &.win-maximized {
+    position: fixed;
+    inset: 0;
+    z-index: 999;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+
+    .body {
+      flex: 1;
+      overflow-y: auto;
+    }
+  }
+
+  &.win-closed { display: none; }
+}
+
+// Shared title-bar button chrome — used in .win .tbar and .wa .wa-title
+.tb-btns {
+  display: flex;
+  gap: 3px;
+  flex-shrink: 0;
+
+  .tb-btn {
+    width: 15px;
+    height: 13px;
+    display: grid;
+    place-items: center;
+    background: var(--chrome);
+    border: 1px solid;
+    border-color: var(--chrome-l) var(--chrome-dd) var(--chrome-dd) var(--chrome-l);
+    color: #000;
+    font-family: var(--comic);
+    font-weight: 700;
+    font-size: 10px;
+    line-height: 1;
+    padding: 0;
+    cursor: pointer;
+
+    &:active {
+      border-color: var(--chrome-dd) var(--chrome-l) var(--chrome-l) var(--chrome-dd);
+    }
+  }
+}
+
+// Fixed taskbar — Win2000 style: [Start] [tasks] [tray/clock]
+#win-taskbar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 28px;
+  background: var(--chrome);
+  border-top: 2px solid;
+  border-color: var(--chrome-l) var(--chrome-dd) var(--chrome-dd) var(--chrome-l);
+  padding: 2px 4px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  z-index: 1000;
+
+  // Start button — favicon + bold label, slightly raised
+  .tb-start {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 1px 8px 1px 4px;
+    height: 22px;
+    background: var(--chrome);
+    border: 2px solid;
+    border-color: var(--chrome-l) var(--chrome-dd) var(--chrome-dd) var(--chrome-l);
+    cursor: pointer;
+    font-family: var(--pix);
+    font-size: 9px;
+    font-weight: 700;
+    color: #000;
+    white-space: nowrap;
+    flex-shrink: 0;
+
+    img { width: 16px; height: 16px; image-rendering: pixelated; }
+
+    &:active {
+      border-color: var(--chrome-dd) var(--chrome-l) var(--chrome-l) var(--chrome-dd);
+    }
+  }
+
+  // Task button strip — takes remaining space
+  .tb-tasks {
+    display: flex;
+    align-items: center;
+    gap: 2px;
+    flex: 1;
+    overflow: hidden;
+  }
+
+  .tb-task {
+    display: flex;
+    align-items: center;
+    padding: 2px 8px;
+    background: var(--chrome);
+    border: 1px solid;
+    border-color: var(--chrome-l) var(--chrome-dd) var(--chrome-dd) var(--chrome-l);
+    cursor: pointer;
+    font-family: var(--pix);
+    font-size: 9px;
+    color: #000;
+    white-space: nowrap;
+    max-width: 220px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+
+    &:active {
+      border-color: var(--chrome-dd) var(--chrome-l) var(--chrome-l) var(--chrome-dd);
+    }
+  }
+
+  // System tray — sunken inset, right-aligned
+  .tb-tray {
+    display: flex;
+    align-items: center;
+    padding: 1px 6px;
+    height: 20px;
+    border: 1px solid;
+    border-color: var(--chrome-dd) var(--chrome-l) var(--chrome-l) var(--chrome-dd);
+    flex-shrink: 0;
+  }
+
+  .tb-clock {
+    font-family: var(--pix);
+    font-size: 9px;
+    color: #000;
+    white-space: nowrap;
   }
 }

--- a/themes/squalr/assets/css/_winamp.scss
+++ b/themes/squalr/assets/css/_winamp.scss
@@ -36,28 +36,6 @@ a.wa-name {
   &:hover { text-decoration: underline; opacity: .85; }
 }
 
-// Title bar window buttons
-.wa-wbtns { display: flex; gap: 2px; flex-shrink: 0; }
-
-.wa-wb {
-  width: 14px;
-  height: 12px;
-  padding: 0;
-  border: 1px solid;
-  border-color: var(--chrome-l) var(--chrome-dd) var(--chrome-dd) var(--chrome-l);
-  background: var(--chrome);
-  color: #000;
-  font-family: var(--comic);
-  font-size: 9px;
-  line-height: 1;
-  font-weight: 700;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-
-  &:active { border-color: var(--chrome-dd) var(--chrome-l) var(--chrome-l) var(--chrome-dd); }
-}
 
 // Dark body area
 .wa-body { background: #232323; padding: 4px; }
@@ -294,6 +272,14 @@ a.wa-name {
 
 .wa-pl-idx   { flex-shrink: 0; width: 14px; text-align: right; }
 .wa-pl-track { overflow: hidden; text-overflow: ellipsis; }
+
+// JS-toggled states
+.wa.wa-shaded .wa-body,
+.wa.wa-shaded #np-art,
+.wa.wa-shaded .wa-playlist,
+.wa.wa-shaded .wa-footer { display: none; }
+
+.wa.wa-closed { display: none; }
 
 // ---- Footer (scrobble count) ----
 

--- a/themes/squalr/layouts/_default/baseof.html
+++ b/themes/squalr/layouts/_default/baseof.html
@@ -50,7 +50,7 @@
     <div class="win">
       <div class="tbar">
         <span>C:\{{ $sec }}\{{ .Title }}</span>
-        <span class="tb-btns" aria-hidden="true"><i>_</i><i>▢</i><i>✕</i></span>
+        {{ partial "win-btns.html" . }}
       </div>
       <div class="body">
         {{ block "main" . }}{{ .Content }}{{ end }}

--- a/themes/squalr/layouts/index.html
+++ b/themes/squalr/layouts/index.html
@@ -73,11 +73,7 @@
       <div class="wa" role="region" aria-label="Now playing">
         <div class="wa-title">
           <a href="https://www.last.fm/user/squalrus" class="wa-name" target="_blank" rel="noopener noreferrer" aria-label="last.fm profile">♫ LAST.FM</a>
-          <div class="wa-wbtns" aria-hidden="true">
-            <button class="wa-wb" tabindex="-1">_</button>
-            <button class="wa-wb" tabindex="-1">□</button>
-            <button class="wa-wb" tabindex="-1">×</button>
-          </div>
+            {{ partial "win-btns.html" . }}
         </div>
         <div class="wa-body">
           <div class="wa-lcd" aria-live="polite" aria-atomic="true">
@@ -158,7 +154,7 @@
       <div class="win">
         <div class="tbar">
           <span>C:\SQUALRUS\welcome.exe</span>
-          <span class="tb-btns" aria-hidden="true"><i>_</i><i>▢</i><i>✕</i></span>
+          {{ partial "win-btns.html" . }}
         </div>
         <div class="body welcome">
           <p><b class="pop">Hey! I'm Chad.</b> 🏄 Sr Consultant at <a href="https://duradigital.com" target="_blank" rel="noopener noreferrer">Dura Digital</a> — helping teams ship real products for real people. Off the clock I build things that make me happy and teach me something along the way. Usually both.</p>
@@ -194,7 +190,7 @@
       <div id="guestbook" class="win">
         <div class="tbar">
           <span>★ SIGN MY GUESTBOOK ★</span>
-          <span class="tb-btns" aria-hidden="true"><i>_</i><i>▢</i><i>✕</i></span>
+          {{ partial "win-btns.html" . }}
         </div>
         <div class="body">
           <div style="font-family:var(--term);font-size:18px;color:var(--neon-2);text-align:center;margin-bottom:10px" aria-hidden="true">don't be a lurker — leave a mark! ✍</div>

--- a/themes/squalr/layouts/partials/pcard.html
+++ b/themes/squalr/layouts/partials/pcard.html
@@ -4,7 +4,7 @@
 {{- $slug := .File.ContentBaseName -}}
 {{- $notes := where site.RegularPages "Params.projects" "intersect" (slice $slug) -}}
 <article class="pcard">
-  <div class="pchrome"><h3 class="pname"><a href="{{ .Permalink }}">{{ .Title }}</a></h3><span class="pstat {{ $statusClass }}">{{ .Params.status | upper }}</span></div>
+  <div class="pchrome"><h3 class="pname"><a href="{{ .Permalink }}">{{ .Title }}</a>{{- if ge .Date (now.AddDate 0 0 -45) }} <span class="newgif blink">NEW!</span>{{ end }}</h3><span class="pstat {{ $statusClass }}">{{ .Params.status | upper }}</span></div>
   <div class="shot">
     {{- with .Params.image }}
     {{- $assetPath := strings.TrimLeft "/" . }}

--- a/themes/squalr/layouts/partials/win-btns.html
+++ b/themes/squalr/layouts/partials/win-btns.html
@@ -1,0 +1,6 @@
+{{- /* Win95 title-bar buttons. Included in every .tbar; wired by cybershack.js initWindowControls(). */ -}}
+<span class="tb-btns">
+  <button class="tb-btn" data-action="minimize" title="Minimize" aria-label="Minimize">_</button>
+  <button class="tb-btn" data-action="maximize" title="Maximize" aria-label="Maximize">▢</button>
+  <button class="tb-btn" data-action="close"    title="Close"    aria-label="Close">✕</button>
+</span>

--- a/themes/squalr/static/cybershack.js
+++ b/themes/squalr/static/cybershack.js
@@ -215,6 +215,208 @@
     });
   }
 
+  /* ---------- WINDOW CONTROLS (Win95 + WinAmp) ---------- */
+
+  // Shared fixed taskbar — used by both window controls and WinAmp controls
+  var _tbEl    = null;
+  var _tbItems = {}; // key → { title, restoreFn }
+  var _winReset = null; // set by initWindowControls — resets all .win states
+  var _waReset  = null; // set by initWinampControls — resets WinAmp state
+
+  function _tbAdd(key, title, restoreFn) {
+    _tbItems[key] = { title: title, restoreFn: restoreFn };
+    _tbRender();
+  }
+
+  function _tbRemove(key) {
+    delete _tbItems[key];
+    _tbRender();
+  }
+
+  function _tbRender() {
+    var keys = Object.keys(_tbItems);
+    if (!keys.length) {
+      if (_tbEl) { _tbEl.remove(); _tbEl = null; }
+      return;
+    }
+    if (!_tbEl) {
+      _tbEl = document.createElement('div');
+      _tbEl.id = 'win-taskbar';
+      _tbEl.setAttribute('role', 'toolbar');
+      _tbEl.setAttribute('aria-label', 'Taskbar');
+      document.body.appendChild(_tbEl);
+
+      // Start button (Win2000 style — favicon + bold label)
+      var startBtn = document.createElement('button');
+      startBtn.className = 'tb-start';
+      startBtn.setAttribute('aria-label', 'Start');
+      var startImg = document.createElement('img');
+      startImg.src = '/img/favicon.ico';
+      startImg.alt = '';
+      startImg.setAttribute('aria-hidden', 'true');
+      startImg.width = 16;
+      startImg.height = 16;
+      startBtn.appendChild(startImg);
+      var startText = document.createElement('span');
+      startText.textContent = 'Start';
+      startBtn.appendChild(startText);
+      startBtn.addEventListener('click', function () {
+        sessionStorage.clear();
+        if (_winReset) _winReset();
+        if (_waReset)  _waReset();
+      });
+      _tbEl.appendChild(startBtn);
+
+      // Task area (window restore buttons go here)
+      var taskArea = document.createElement('div');
+      taskArea.className = 'tb-tasks';
+      _tbEl.appendChild(taskArea);
+
+      // System tray + clock
+      var tray = document.createElement('div');
+      tray.className = 'tb-tray';
+      var clock = document.createElement('time');
+      clock.className = 'tb-clock';
+      tray.appendChild(clock);
+      _tbEl.appendChild(tray);
+
+      function tickClock() {
+        var now = new Date();
+        var h = now.getHours() % 12 || 12;
+        var m = now.getMinutes();
+        clock.textContent = h + ':' + (m < 10 ? '0' + m : m) + (now.getHours() >= 12 ? ' PM' : ' AM');
+        clock.setAttribute('datetime', now.toTimeString().slice(0, 5));
+      }
+      tickClock();
+      setInterval(tickClock, 1000);
+    }
+
+    // Rebuild only the task buttons — Start and clock stay intact
+    var taskArea = _tbEl.querySelector('.tb-tasks');
+    taskArea.innerHTML = '';
+    keys.forEach(function (key) {
+      var item = _tbItems[key];
+      var btn = document.createElement('button');
+      btn.className = 'tb-task';
+      btn.textContent = '▣ ' + item.title;
+      btn.addEventListener('click', function () { item.restoreFn(); });
+      taskArea.appendChild(btn);
+    });
+  }
+
+  function initWindowControls() {
+    var wins = document.querySelectorAll('.win');
+    if (!wins.length) return;
+    var winData = [];
+
+    function applyState(w, newState) {
+      w.state = newState;
+      if (newState) sessionStorage.setItem(w.key, newState);
+      else sessionStorage.removeItem(w.key);
+
+      w.el.classList.remove('win-minimized', 'win-maximized', 'win-closed');
+      if (newState) w.el.classList.add('win-' + newState);
+
+      var maxBtn = w.el.querySelector('.tb-btn[data-action="maximize"]');
+      if (maxBtn) {
+        maxBtn.textContent = newState === 'maximized' ? '❐' : '▢';
+        maxBtn.setAttribute('aria-label', newState === 'maximized' ? 'Restore' : 'Maximize');
+        maxBtn.setAttribute('title',      newState === 'maximized' ? 'Restore' : 'Maximize');
+      }
+
+      if (newState === 'minimized' || newState === 'closed') {
+        _tbAdd(w.key, w.title, function () { applyState(w, ''); });
+      } else {
+        _tbRemove(w.key);
+      }
+    }
+
+    // Phase 1: collect windows + saved state
+    wins.forEach(function (winEl, idx) {
+      var titleEl = winEl.querySelector('.tbar > span:first-child');
+      var title = (titleEl ? titleEl.textContent.trim() : '') || ('Window ' + (idx + 1));
+      var key = 'win:' + location.pathname + ':' + idx;
+      winData.push({ el: winEl, title: title, key: key, state: sessionStorage.getItem(key) || '' });
+    });
+
+    // Phase 2: apply saved classes + seed taskbar entries
+    winData.forEach(function (w) {
+      w.el.classList.remove('win-minimized', 'win-maximized', 'win-closed');
+      if (w.state) w.el.classList.add('win-' + w.state);
+      var maxBtn = w.el.querySelector('.tb-btn[data-action="maximize"]');
+      if (maxBtn && w.state === 'maximized') {
+        maxBtn.textContent = '❐';
+        maxBtn.setAttribute('aria-label', 'Restore');
+        maxBtn.setAttribute('title', 'Restore');
+      }
+      if (w.state === 'minimized' || w.state === 'closed') {
+        _tbAdd(w.key, w.title, function () { applyState(w, ''); });
+      }
+    });
+
+    // Register global reset so the Start button can restore all windows
+    _winReset = function () { winData.forEach(function (w) { applyState(w, ''); }); };
+
+    // Phase 3: wire up button + dblclick handlers
+    winData.forEach(function (w) {
+      w.el.querySelectorAll('.tb-btn').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+          var a = btn.dataset.action;
+          if (a === 'minimize')      applyState(w, w.state === 'minimized' ? '' : 'minimized');
+          else if (a === 'maximize') applyState(w, w.state === 'maximized' ? '' : 'maximized');
+          else if (a === 'close')    applyState(w, 'closed');
+        });
+      });
+      var tbar = w.el.querySelector('.tbar');
+      if (tbar) {
+        tbar.addEventListener('dblclick', function (e) {
+          if (e.target.closest('.tb-btns')) return;
+          applyState(w, w.state === 'maximized' ? '' : 'maximized');
+        });
+      }
+    });
+  }
+
+  function initWinampControls() {
+    var wa = document.querySelector('.wa');
+    if (!wa) return;
+    var wbtns = wa.querySelectorAll('.tb-btn');
+    if (!wbtns.length) return;
+
+    var TITLE = '♫ LAST.FM';
+    var SK    = 'wa:s:' + location.pathname; // shaded key
+    var CK    = 'wa:c:' + location.pathname; // closed key
+
+    var shaded = sessionStorage.getItem(SK) === '1';
+    var closed = sessionStorage.getItem(CK) === '1';
+
+    function setState(newShaded, newClosed) {
+      shaded = newShaded;
+      closed = newClosed;
+      sessionStorage.setItem(SK, shaded ? '1' : '');
+      sessionStorage.setItem(CK, closed ? '1' : '');
+      wa.classList.toggle('wa-shaded', shaded);
+      wa.classList.toggle('wa-closed', closed);
+      if (closed) _tbAdd(CK, TITLE, function () { setState(false, false); });
+      else        _tbRemove(CK);
+    }
+
+    // minimize/maximize → toggle shade; close → close player
+    wbtns.forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        if (btn.dataset.action === 'close') setState(false, true);
+        else                                setState(!shaded, false);
+      });
+    });
+
+    // Register global reset so the Start button can restore the player
+    _waReset = function () { setState(false, false); };
+
+    // Restore saved state on load
+    if (closed)      setState(false, true);
+    else if (shaded) setState(true,  false);
+  }
+
   /* ---------- SPARKLE CURSOR TRAIL ---------- */
   var GLYPHS = ['✦', '✧', '★', '+', '·'];
   var trailOn = true;
@@ -258,6 +460,8 @@
     initNowPlaying();
     initGuestbook();
     initSparkles();
+    initWindowControls();
+    initWinampControls();
   }
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', boot);


### PR DESCRIPTION
All .win and WinAmp title-bar buttons are now wired up via a shared win-btns.html partial. Minimize collapses to title bar, maximize fills the viewport (dblclick title bar also toggles), close hides entirely. WinAmp _ / square toggle shade mode, x closes the player. Minimized and closed panels appear as restore buttons in a fixed Win2000-style taskbar: Start (favicon + label) | task strip | live clock in tray. Clicking Start clears sessionStorage and restores all windows and the player to their default visible state. Also: NEW! badge on project cards dated within the last 45 days, matching the posts list badge.