### PR TITLE
improvement: tag size variants + refined project detail layout (v1.7.3)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -55,10 +55,7 @@ _No open bug items._
 
 ### Improvements
 
-| Title | Effort | Value |
-| --- | --- | --- |
-| [New tag style variants](#new-tag-style-variants) | M | M |
-| [Refine project detail page layout](#refine-project-detail-page-layout) | M | M |
+_No open improvement items._
 
 ### Cleanup
 
@@ -83,39 +80,6 @@ _No open cleanup items._
 - State: track minimized/closed windows in `cybershack.js` (same place the existing window controls logic lives). The Start menu queries that state to populate "restore" items.
 - Interaction with the existing win controls (v1.6.5): the close/minimize buttons are already functional — wire the Start menu into that same event flow.
 - Open question: should Start always show, or only after first minimize? "Only after first interaction" feels more earned and avoids visual noise on load.
-
----
-
-### New tag style variants
-
-**Type:** improvement
-
-**Why** — Tags currently use a single style across all contexts (post metadata, project cards, tag listing page). Offering a small, compact variant for cards and a larger, more prominent variant for the `/tags/` page improves visual hierarchy and makes tags feel appropriately weighted in each context.
-
-**Notes:**
-
-- Audit current tag usage: post frontmatter/detail, project cards, post body in-line, `/tags/` listing.
-- Consider CSS class variants like `.tag--small` and `.tag--large` (or `.tag.card` / `.tag.listing`).
-- Small version: tighter padding, smaller font, subtle background — fits cleanly on project cards.
-- Large version: roomier, better for scanability on the tags archive page.
-- Keep the visual language consistent; the difference should be scale/breathing room, not color or decoration.
-
----
-
-### Refine project detail page layout
-
-**Type:** improvement
-
-**Why** — The project detail page (single project view) currently mixes status, links (repo/demo/other), and tags together in a cramped header area. Better visual separation and hierarchy makes the page easier to scan and the metadata feel more organized and intentional.
-
-**Notes:**
-
-- Edit `themes/squalr/layouts/projects/single.html` to reorganize the header area.
-- Give status its own visual block with clear labeling.
-- Group repo/demo/custom links together (already being reworked in the "Read more link on project cards" item — coordinate styling).
-- Separate tags into their own section below, using the small tag variant from "New tag style variants" improvement.
-- In CLAUDE.md project section, update the cross-link description: currently says "A post with `projects: [...]` shows a `◇ field notes` cross-link" — change to mention "posts" instead of "field notes".
-- Test across projects with varying amounts of metadata (few tags, many tags, many links, etc.).
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 User-visible changes to squalr.us, newest first. Format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the site uses [semver](https://semver.org/) — see [BACKLOG.md](./BACKLOG.md#shipping-a-backlog-item) for how each backlog item gets versioned and migrated here.
 
+## [1.7.3] — 2026-06-05
+
+### Changed
+
+- **Tag size variants.** Tags now come in three sizes: the default pill (post meta), a compact `.tag--small` (project cards and detail-page tech stack), and a spacious `.tag--large` (the `/tags/` taxonomy listing). Visual language — teal pill, black border — stays identical; only scale and padding differ. (`_tags.scss`, `pcard.html`, `terms.html`, `_projects.scss`, `_project-detail.scss`)
+- **Refined project detail page layout.** The header area is reorganized into three explicit labeled rows — `status`, `links`, and `tech` — instead of a single mixed flex row with a floating tech block below. Each row has a small uppercase label (e.g. "status", "links", "tech") for scanability. Tech tags now use the compact `tag--small` variant. The related-posts heading updated from "Field notes" to "Posts about this project". (`projects/single.html`, `_project-detail.scss`)
+
 ## [1.7.2] — 2026-06-05
 
 ### Added

--- a/themes/squalr/assets/css/_project-detail.scss
+++ b/themes/squalr/assets/css/_project-detail.scss
@@ -2,17 +2,45 @@
 // Project detail page (projects/single.html)
 // ============================================================
 
-// Meta row: status pill, links, tech tags
+// Meta block: labeled rows for status, links, tech
 .project-detail-meta {
+  margin: 8px 0 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+
+.pdmeta-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px 10px;
+}
+
+.pdmeta-label {
   font-family: var(--term);
-  font-size: 16px;
+  font-size: 11px;
+  color: var(--ink-2);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  white-space: nowrap;
+  min-width: 40px;
+}
+
+.pdmeta-links {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px 14px;
-  align-items: center;
-  margin: 6px 0 10px;
+  gap: 6px 12px;
+  font-family: var(--term);
+  font-size: 15px;
 
   a { color: var(--link); }
+}
+
+.pdmeta-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
 }
 
 .project-status {
@@ -26,23 +54,6 @@
   &.status-wip,
   &.status-paused   { background: var(--fire); }
   &.status-archived { background: var(--chrome-d); color: #fff; }
-}
-
-.project-detail-tech {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-  margin: 8px 0 14px;
-
-  // Reuses the same teal pill as .ptags span
-  .tag {
-    font-family: var(--term);
-    font-size: 14px;
-    color: #000;
-    background: #7fe3e3;
-    padding: 1px 8px;
-    border: 1px solid #000;
-  }
 }
 
 // ---- Hero image ----

--- a/themes/squalr/assets/css/_projects.scss
+++ b/themes/squalr/assets/css/_projects.scss
@@ -72,16 +72,6 @@
   &:hover { border-color: var(--hot); box-shadow: 0 4px 14px rgba(91, 26, 166, .22); }
 }
 
-// Tech tag pills (shared between cards and the project detail page)
-.ptags span {
-  font-family: var(--term);
-  font-size: 14px;
-  color: #000;
-  background: #7fe3e3;
-  padding: 0 7px;
-  border: 1px solid #000;
-}
-
 // ============================================================
 // Screenshot + terminal banner containers
 // ============================================================

--- a/themes/squalr/assets/css/_tags.scss
+++ b/themes/squalr/assets/css/_tags.scss
@@ -1,6 +1,6 @@
-// Tag pills — post meta and taxonomy list pages
+// Tag pills — post meta, project cards, taxonomy list pages
 a.tag,
-.tags-list-item-title {
+span.tag {
   font-family: var(--term);
   font-size: 15px;
   color: #000;
@@ -9,8 +9,20 @@ a.tag,
   border: 1px solid #000;
   text-decoration: none;
   white-space: nowrap;
+}
 
-  &:hover { background: var(--zap); color: #000; }
+a.tag:hover { background: var(--zap); color: #000; }
+
+// Compact variant — project cards, detail-page tech stack
+.tag--small {
+  font-size: 12px;
+  padding: 0 6px;
+}
+
+// Spacious variant — /tags/ taxonomy listing page
+.tag--large {
+  font-size: 17px;
+  padding: 2px 11px;
 }
 
 .tags-list {

--- a/themes/squalr/layouts/_default/terms.html
+++ b/themes/squalr/layouts/_default/terms.html
@@ -4,7 +4,7 @@
   <ul class="tags-list">
     {{ range .Data.Terms.ByCount }}
       <li class="tags-list-item">
-        <a class="tags-list-item-title" href="{{ .Page.Permalink }}">{{ .Page.Title }} ({{ .Count }})</a>
+        <a class="tag tag--large" href="{{ .Page.Permalink }}">{{ .Page.Title }} ({{ .Count }})</a>
       </li>
     {{ end }}
   </ul>

--- a/themes/squalr/layouts/partials/pcard.html
+++ b/themes/squalr/layouts/partials/pcard.html
@@ -30,7 +30,7 @@
   </div>
   <div class="pbody">
     {{- with .Params.description }}<p class="pdesc">{{ . }}</p>{{ end }}
-    {{- with .Params.tech }}<div class="ptags">{{ range . }}<span>{{ . }}</span>{{ end }}</div>{{ end }}
+    {{- with .Params.tech }}<div class="ptags">{{ range . }}<span class="tag tag--small">{{ . }}</span>{{ end }}</div>{{ end }}
     <div class="pfoot">
       <span class="plinks">
         <a href="{{ .Permalink }}">read more</a>

--- a/themes/squalr/layouts/projects/single.html
+++ b/themes/squalr/layouts/projects/single.html
@@ -1,21 +1,34 @@
 {{ define "main" }}
+  {{- $statusEmoji := dict "active" "🟢" "wip" "🚧" "archived" "📦" "paused" "⏸️" }}
   <article class="post">
     <header class="post-header">
       <h1 class="post-title">{{ .Title }}</h1>
       <div class="project-detail-meta">
         {{- with .Params.status }}
-        {{- $statusEmoji := dict "active" "🟢" "wip" "🚧" "archived" "📦" "paused" "⏸️" }}
-        <span class="project-status status-{{ . }}">{{ with index $statusEmoji . }}{{ . }} {{ end }}{{ . }}</span>
+        <div class="pdmeta-row">
+          <span class="pdmeta-label">status</span>
+          <span class="project-status status-{{ . }}">{{ with index $statusEmoji . }}{{ . }} {{ end }}{{ . }}</span>
+        </div>
         {{- end }}
-        {{- with .Params.repo }}<a href="{{ . }}" target="_blank" rel="noreferrer noopener">github↗</a>{{ end }}
-        {{- with .Params.demo }}<a href="{{ . }}" target="_blank" rel="noreferrer noopener">live↗</a>{{ end }}
-        {{- range .Params.links }}<a href="{{ .url }}" target="_blank" rel="noreferrer noopener">{{ replaceRE `[↗→\s]+$` "" .label | lower }}↗</a>{{ end }}
+        {{- if or .Params.repo .Params.demo .Params.links }}
+        <div class="pdmeta-row">
+          <span class="pdmeta-label">links</span>
+          <span class="pdmeta-links">
+            {{- with .Params.repo }}<a href="{{ . }}" target="_blank" rel="noreferrer noopener">github↗</a>{{ end }}
+            {{- with .Params.demo }}<a href="{{ . }}" target="_blank" rel="noreferrer noopener">live↗</a>{{ end }}
+            {{- range .Params.links }}<a href="{{ .url }}" target="_blank" rel="noreferrer noopener">{{ replaceRE `[↗→\s]+$` "" .label | lower }}↗</a>{{ end }}
+          </span>
+        </div>
+        {{- end }}
+        {{- with .Params.tech }}
+        <div class="pdmeta-row">
+          <span class="pdmeta-label">tech</span>
+          <div class="pdmeta-tags">
+            {{- range . }}<span class="tag tag--small">{{ . }}</span>{{ end }}
+          </div>
+        </div>
+        {{- end }}
       </div>
-      {{- with .Params.tech }}
-      <div class="project-detail-tech">
-        {{- range . }}<span class="tag">{{ . }}</span>{{ end }}
-      </div>
-      {{- end }}
     </header>
     {{- with .Params.image }}
     {{- $assetPath := strings.TrimLeft "/" . }}
@@ -71,7 +84,7 @@
     {{- $related := where site.RegularPages "Params.projects" "intersect" (slice $slug) }}
     {{- with $related }}
     <div class="related-section">
-      <h2>◇ Field notes about this project</h2>
+      <h2>◇ Posts about this project</h2>
       <ul class="posts">
         {{- range . }}
         {{ partial "post-li.html" (dict "page" .) }}


### PR DESCRIPTION
- New .tag--small (12px, 0 6px) and .tag--large (17px, 2px 11px) variants alongside the existing base tag pill; visual language (teal, black border) unchanged — only scale and breathing room differ
- /tags/ listing now uses tag--large for better scanability
- Project card tech stack switches to tag--small (was bare span with inline styles)
- Project detail header reorganised into three labeled rows — status / links / tech — replacing the flat mixed flex row; tech tags use tag--small
- Removed redundant .ptags span and .project-detail-tech .tag override blocks