### PR TITLE
feat: gallery lightbox with keyboard navigation (v1.8.0)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -48,7 +48,6 @@ _No open bug items._
 | Title | Effort | Value |
 | --- | --- | --- |
 | Scheduled rebuild so future-dated posts auto-publish | S | M |
-| CSS-only gallery lightbox | S | M |
 | AIM-style buddy list widget backed by Steam friends API | M | H |
 | [Win95 Start menu](#win95-start-menu) | L | H |
 | Replace fake guestbook with GitHub Discussions (Giscus) | M | M |
@@ -108,21 +107,6 @@ _No open cleanup items._
 - Keep `buildFuture` **false** — that's the point (future posts stay hidden until their date passes, then a scheduled build picks them up). Don't set `buildFuture: true`, which would publish them immediately.
 - Tradeoff: a daily cron means up to ~24h latency between the post's date and it going live; tighten the cron if you want finer granularity. Note GitHub's scheduled workflows can be delayed under load and are disabled after 60 days of repo inactivity.
 - Document the "set a future `date`, it publishes on the next scheduled build" behavior in CLAUDE.md's posting section when this ships.
-
----
-
-### CSS-only gallery lightbox
-
-**Type:** feature
-
-**Why:** Project galleries currently open each screenshot full-size in a new browser tab (a plain `<a target="_blank">`). That works and stays zero-JS, but it kicks the visitor out of the page. A lightbox — click a thumbnail, it opens in an overlay, click away to close — keeps them in flow and reads more like a real project showcase.
-
-**Notes:**
-
-- Keep it zero-JS. The `:target` pseudo-class lightbox pattern works: each gallery image links to `#img-<n>`, a sibling overlay element matches `:target` and shows via CSS, and a full-cover close link resets the hash. Hugo can generate the IDs in the `range` loop in `themes/squalr/layouts/projects/single.html`.
-- Respect `prefers-reduced-motion` for the fade.
-- Trap: `:target` lightboxes can fight the browser back button and scroll position. Test that closing returns the visitor to where they were on the page.
-- If `:target` gets fiddly, a tiny vanilla-JS lightbox (no dependency) is the fallback — but try CSS first to keep the no-build ethos.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 User-visible changes to squalr.us, newest first. Format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the site uses [semver](https://semver.org/) — see [BACKLOG.md](./BACKLOG.md#shipping-a-backlog-item) for how each backlog item gets versioned and migrated here.
 
+## [1.8.0] — 2026-06-05
+
+### Added
+
+- **Gallery lightbox with keyboard navigation.** Clicking a project gallery thumbnail now opens a full-screen overlay instead of navigating to a new tab. The lightbox is driven by the CSS `:target` pseudo-class (zero JavaScript for open/close) and styled as a Win95 window (gradient title bar, outset border, pixel-font label). Arrow keys (← →) cycle through images; Escape closes. Fade-in animation respects `prefers-reduced-motion`. (`projects/single.html`, `_project-detail.scss`, `_animations.scss`, `_responsive.scss`, `cybershack.js`)
+- **Glizzy Relay gallery captions.** All six gallery screenshots now have captions (Homepage, Events, FAQ, Profile, Event detail, Scoreboard), visible in the lightbox title bar and caption strip. (`content/projects/glizzyrelay.com.md`)
+
 ## [1.7.3] — 2026-06-05
 
 ### Changed

--- a/content/projects/glizzyrelay.com.md
+++ b/content/projects/glizzyrelay.com.md
@@ -7,17 +7,17 @@ image: /img/projects/glizzyrelay.com/featured.png
 # Gallery — shown when drilling into this project:
 gallery:
    - src: /img/projects/glizzyrelay.com/1-home.png
-     caption: ""
+     caption: "Homepage"
    - src: /img/projects/glizzyrelay.com/2-events.png
-     caption: ""
+     caption: "Events"
    - src: /img/projects/glizzyrelay.com/3-faq.png
-     caption: ""
+     caption: "FAQ"
    - src: /img/projects/glizzyrelay.com/4-profile.png
-     caption: ""
+     caption: "Profile"
    - src: /img/projects/glizzyrelay.com/5-event.png
-     caption: ""
+     caption: "Event detail"
    - src: /img/projects/glizzyrelay.com/6-scoreboard.png
-     caption: ""
+     caption: "Scoreboard"
 tech: [TypeScript, React, Vite, Tailwind CSS, Supabase, PostgreSQL, Netlify]
 demo: "https://glizzyrelay.com"
 ---

--- a/themes/squalr/assets/css/_animations.scss
+++ b/themes/squalr/assets/css/_animations.scss
@@ -51,3 +51,10 @@
 @keyframes mq {
   to { transform: translateX(-100%); }
 }
+
+// ---- Lightbox fade ----
+
+@keyframes lb-fade {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}

--- a/themes/squalr/assets/css/_project-detail.scss
+++ b/themes/squalr/assets/css/_project-detail.scss
@@ -107,7 +107,7 @@
   border: 2px ridge var(--neon-2);
   background: var(--paper-2);
 
-  img { width: 100%; display: block; height: auto; }
+  img { width: 100%; display: block; height: auto; cursor: zoom-in; }
 
   figcaption {
     font-family: var(--term);
@@ -115,4 +115,106 @@
     padding: 3px 6px;
     color: var(--ink-2);
   }
+}
+
+// ---- Gallery lightbox (CSS :target) ----
+
+.gallery-lightbox {
+  display: none;
+  position: fixed;
+  inset: 0;
+  z-index: 500;
+  align-items: center;
+  justify-content: center;
+
+  &:target { display: flex; }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .gallery-lightbox:target { animation: lb-fade 0.15s ease; }
+}
+
+.gallery-lb-bg {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.85);
+  cursor: zoom-out;
+}
+
+.gallery-lb-win {
+  position: relative;
+  z-index: 1;
+  background: var(--chrome);
+  border: 2px solid;
+  border-color: var(--chrome-l) var(--chrome-dd) var(--chrome-dd) var(--chrome-l);
+  max-width: min(90vw, 1024px);
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.gallery-lb-tbar {
+  background: linear-gradient(90deg, var(--navy), #1084d0);
+  color: #fff;
+  font-family: var(--pix);
+  font-size: 9px;
+  letter-spacing: 0.5px;
+  padding: 4px 6px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+  flex-shrink: 0;
+
+  > span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}
+
+.gallery-lb-x {
+  background: var(--chrome);
+  color: #000;
+  border: 1px solid;
+  border-color: var(--chrome-l) var(--chrome-dd) var(--chrome-dd) var(--chrome-l);
+  font-family: var(--comic);
+  font-weight: 700;
+  font-size: 10px;
+  width: 15px;
+  height: 13px;
+  display: grid;
+  place-items: center;
+  text-decoration: none;
+  flex-shrink: 0;
+
+  &:active { border-color: var(--chrome-dd) var(--chrome-l) var(--chrome-l) var(--chrome-dd); }
+}
+
+.gallery-lb-body {
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background: #000;
+
+  img {
+    display: block;
+    max-width: 100%;
+    max-height: calc(90vh - 32px);
+    height: auto;
+    width: auto;
+    object-fit: contain;
+  }
+}
+
+.gallery-lb-cap {
+  font-family: var(--term);
+  font-size: 14px;
+  color: #ccc;
+  padding: 4px 8px;
+  margin: 0;
+  text-align: center;
+  width: 100%;
 }

--- a/themes/squalr/assets/css/_responsive.scss
+++ b/themes/squalr/assets/css/_responsive.scss
@@ -14,7 +14,8 @@
   .blink,
   .shot::after,
   .project-hero-media::after,
-  .foot-constr .hat {
+  .foot-constr .hat,
+  .gallery-lightbox:target {
     animation: none;
   }
 }

--- a/themes/squalr/assets/js/cybershack.js
+++ b/themes/squalr/assets/js/cybershack.js
@@ -417,6 +417,33 @@
     else if (shaded) setState(true,  false);
   }
 
+  /* ---------- GALLERY LIGHTBOX (keyboard nav) ---------- */
+  function initGalleryLightbox() {
+    var boxes = document.querySelectorAll('.gallery-lightbox');
+    if (!boxes.length) return;
+    var count = boxes.length;
+
+    function currentIndex() {
+      var m = location.hash.match(/^#img-(\d+)$/);
+      return m ? parseInt(m[1], 10) : -1;
+    }
+
+    document.addEventListener('keydown', function (e) {
+      var idx = currentIndex();
+      if (idx === -1) return;
+      if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+        e.preventDefault();
+        location.hash = '#img-' + ((idx + 1) % count);
+      } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+        e.preventDefault();
+        location.hash = '#img-' + ((idx - 1 + count) % count);
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        location.hash = '#gallery';
+      }
+    });
+  }
+
   /* ---------- RETRO AD SLOT (random pick) ---------- */
   function initAdSlot() {
     var ads = document.querySelectorAll('.ad-banner');
@@ -470,6 +497,7 @@
     initSparkles();
     initWindowControls();
     initWinampControls();
+    initGalleryLightbox();
   }
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', boot);

--- a/themes/squalr/layouts/projects/single.html
+++ b/themes/squalr/layouts/projects/single.html
@@ -52,32 +52,53 @@
       {{ .Content }}
     </div>
     {{- with .Params.gallery }}
-    <section class="project-gallery">
+    <section class="project-gallery" id="gallery">
       <h2 class="project-gallery-label">📸 screenshots.zip</h2>
       <div class="project-gallery-grid">
-        {{- range . }}
-        {{- $assetPath := strings.TrimLeft "/" .src }}
+        {{- range $i, $item := . }}
+        {{- $assetPath := strings.TrimLeft "/" $item.src }}
         {{- $imgRes := resources.Get $assetPath }}
         <figure class="project-gallery-item">
           {{- if $imgRes }}
           {{- $sm := $imgRes.Resize "683x webp" }}
           {{- $md := $imgRes.Resize "1024x webp" }}
-          {{- $lg := $imgRes.Resize "1366x webp" }}
-          <a href="{{ $lg.RelPermalink }}" target="_blank" rel="noreferrer noopener">
+          <a href="#img-{{ $i }}" aria-label="{{ $item.caption | default $.Title }}">
             <img src="{{ $sm.RelPermalink }}"
-                 srcset="{{ $sm.RelPermalink }} 683w, {{ $md.RelPermalink }} 1024w, {{ $lg.RelPermalink }} 1366w"
+                 srcset="{{ $sm.RelPermalink }} 683w, {{ $md.RelPermalink }} 1024w"
                  sizes="(max-width: 760px) 100vw, 460px"
-                 alt="{{ .caption | default $.Title }}"
+                 alt="{{ $item.caption | default $.Title }}"
                  width="{{ $sm.Width }}" height="{{ $sm.Height }}"
                  loading="lazy" />
           </a>
           {{- else }}
-          <a href="{{ .src }}" target="_blank" rel="noreferrer noopener"><img src="{{ .src }}" alt="{{ .caption | default $.Title }}" loading="lazy" /></a>
+          <a href="#img-{{ $i }}" aria-label="{{ $item.caption | default $.Title }}"><img src="{{ $item.src }}" alt="{{ $item.caption | default $.Title }}" loading="lazy" /></a>
           {{- end }}
-          {{- with .caption }}<figcaption>{{ . }}</figcaption>{{- end }}
+          {{- with $item.caption }}<figcaption>{{ . }}</figcaption>{{- end }}
         </figure>
         {{- end }}
       </div>
+      {{- range $i, $item := . }}
+      {{- $assetPath := strings.TrimLeft "/" $item.src }}
+      {{- $imgRes := resources.Get $assetPath }}
+      <div id="img-{{ $i }}" class="gallery-lightbox">
+        <a href="#gallery" class="gallery-lb-bg" aria-label="Close lightbox"></a>
+        <div class="gallery-lb-win">
+          <div class="gallery-lb-tbar">
+            <span>{{ $item.caption | default $.Title }}</span>
+            <a href="#gallery" class="gallery-lb-x" aria-label="Close lightbox">✕</a>
+          </div>
+          <div class="gallery-lb-body">
+            {{- if $imgRes }}
+            {{- $lg := $imgRes.Resize "1366x webp" }}
+            <img src="{{ $lg.RelPermalink }}" alt="{{ $item.caption | default $.Title }}" width="{{ $lg.Width }}" height="{{ $lg.Height }}" />
+            {{- else }}
+            <img src="{{ $item.src }}" alt="{{ $item.caption | default $.Title }}" />
+            {{- end }}
+            {{- with $item.caption }}<p class="gallery-lb-cap">{{ . }}</p>{{- end }}
+          </div>
+        </div>
+      </div>
+      {{- end }}
     </section>
     {{- end }}
     {{- $slug := .File.ContentBaseName }}


### PR DESCRIPTION
CSS :target lightbox replaces new-tab links on project gallery thumbnails. Win95 window chrome, fade-in (respects prefers-reduced-motion), arrow key cycling, and Escape to close via a small JS keydown handler. Also adds captions to the Glizzy Relay gallery screenshots.