### PR TITLE
fix: allow Discogs image CDN in CSP img-src

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 User-visible changes to squalr.us, newest first. Format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the site uses [semver](https://semver.org/) — see [BACKLOG.md](./BACKLOG.md#shipping-a-backlog-item) for how each backlog item gets versioned and migrated here.
 
+## [1.9.1] — 2026-06-05
+
+### Fixed
+
+- **Discogs album art CSP block.** Added `https://i.discogs.com` to the `img-src` directive. Thumbnail images returned by the Discogs API (`info.thumb`) were blocked, leaving all album art blank in the Columbia House panel. (`staticwebapp.config.json`)
+
 ## [1.9.0] — 2026-06-05
 
 ### Added

--- a/static/staticwebapp.config.json
+++ b/static/staticwebapp.config.json
@@ -14,7 +14,7 @@
     },
     "globalHeaders": {
         "cache-control": "must-revalidate, max-age=604800",
-        "content-security-policy": "default-src 'self' https://squalr.us; script-src 'self' https://www.googletagmanager.com 'sha256-6ZZAev31WN2I95U/Rg8o2VlXSSo1utI7/vTo+yD9Lrg=' https://platform.twitter.com https://gist.github.com; style-src 'self' https://squalr.us/ https://github.githubassets.com 'unsafe-inline'; font-src 'self'; frame-src https://platform.twitter.com; connect-src https://www.google-analytics.com https://www.googletagmanager.com https://ws.audioscrobbler.com https://api.discogs.com; img-src 'self' data: https://www.google-analytics.com https://lastfm.freetls.fastly.net",
+        "content-security-policy": "default-src 'self' https://squalr.us; script-src 'self' https://www.googletagmanager.com 'sha256-6ZZAev31WN2I95U/Rg8o2VlXSSo1utI7/vTo+yD9Lrg=' https://platform.twitter.com https://gist.github.com; style-src 'self' https://squalr.us/ https://github.githubassets.com 'unsafe-inline'; font-src 'self'; frame-src https://platform.twitter.com; connect-src https://www.google-analytics.com https://www.googletagmanager.com https://ws.audioscrobbler.com https://api.discogs.com; img-src 'self' data: https://www.google-analytics.com https://lastfm.freetls.fastly.net https://i.discogs.com",
         "x-frame-options": "DENY"
     },
     "mimeTypes": {}


### PR DESCRIPTION
Adds https://i.discogs.com to the img-src directive so album art
thumbnails returned by the Discogs API render in the Columbia House
collection panel instead of being blocked.

https://claude.ai/code/session_01Tmsmo8ZeyoPc8FxmxQooy2